### PR TITLE
security: scrub redflower805 from AdGuard helper scripts and docs

### DIFF
--- a/docs/network/ADGUARD_DNS_UPDATE_PROCEDURES.md
+++ b/docs/network/ADGUARD_DNS_UPDATE_PROCEDURES.md
@@ -68,19 +68,19 @@
 ```bash
 # Add a DNS rewrite
 curl -X POST "http://192.168.1.224/control/rewrite/add" \
-  -u "root:redflower805" \
+  -u "root:$(infisical-get ADGUARD_ROOT_PASSWORD)" \
   -H "Content-Type: application/json" \
   -d '{"domain":"example.internal.lakehouse.wtf","answer":"192.168.1.110"}'
 
 # Delete a DNS rewrite
 curl -X POST "http://192.168.1.224/control/rewrite/delete" \
-  -u "root:redflower805" \
+  -u "root:$(infisical-get ADGUARD_ROOT_PASSWORD)" \
   -H "Content-Type: application/json" \
   -d '{"domain":"example.internal.lakehouse.wtf","answer":"192.168.1.110"}'
 
 # List all rewrites
 curl -s "http://192.168.1.224/control/rewrite/list" \
-  -u "root:redflower805" | jq
+  -u "root:$(infisical-get ADGUARD_ROOT_PASSWORD)" | jq
 ```
 
 #### Option C: Direct YAML Edit (Use with Caution)
@@ -192,7 +192,7 @@ All internal services route through Traefik at 192.168.1.110.
 ```bash
 # Using API (recommended)
 curl -X POST "http://192.168.1.224/control/rewrite/add" \
-  -u "root:redflower805" \
+  -u "root:$(infisical-get ADGUARD_ROOT_PASSWORD)" \
   -H "Content-Type: application/json" \
   -d '{"domain":"newservice.internal.lakehouse.wtf","answer":"192.168.1.110"}'
 
@@ -205,7 +205,7 @@ dig @192.168.1.224 newservice.internal.lakehouse.wtf +short
 
 ```bash
 curl -X POST "http://192.168.1.224/control/rewrite/add" \
-  -u "root:redflower805" \
+  -u "root:$(infisical-get ADGUARD_ROOT_PASSWORD)" \
   -H "Content-Type: application/json" \
   -d '{"domain":"my-esp-device.local","answer":"192.168.1.XXX"}'
 ```
@@ -412,7 +412,7 @@ systemctl status AdGuardHome
 
 # Add rewrite via API
 curl -X POST "http://192.168.1.224/control/rewrite/add" \
-  -u "root:redflower805" -H "Content-Type: application/json" \
+  -u "root:$(infisical-get ADGUARD_ROOT_PASSWORD)" -H "Content-Type: application/json" \
   -d '{"domain":"NAME.internal.lakehouse.wtf","answer":"192.168.1.110"}'
 
 # Test DNS

--- a/scripts/generate_adguard_rewrites_from_sqlite.py
+++ b/scripts/generate_adguard_rewrites_from_sqlite.py
@@ -3,6 +3,8 @@ import base64
 import json
 import os
 import sqlite3
+import subprocess
+import sys
 from datetime import datetime
 
 import requests
@@ -11,7 +13,17 @@ import requests
 ADGUARD_HOST = "192.168.1.253"
 ADGUARD_PORT = "80"
 ADGUARD_USER = "root"
-ADGUARD_PASS = "redflower805"
+ADGUARD_PASS = os.environ.get("ADGUARD_PASSWORD") or subprocess.run(
+    ["infisical-get", "ADGUARD_ROOT_PASSWORD"],
+    capture_output=True, text=True, check=False,
+).stdout.strip()
+if not ADGUARD_PASS:
+    sys.stderr.write(
+        "ERROR: ADGUARD_PASSWORD not set and infisical-get failed to retrieve "
+        "ADGUARD_ROOT_PASSWORD. Refresh session: "
+        "infisical login --domain=\"https://infisical.internal.lakehouse.wtf\" -i\n"
+    )
+    sys.exit(1)
 INTERNAL_TARGET_IP = "192.168.1.95"
 SNAPSHOT_DIR = "/opt/gitops/npm_proxy_snapshot"
 DRY_RUN_LOG = "/opt/gitops/.last_adguard_dry_run.json"

--- a/scripts/sync_npm_to_adguard.py
+++ b/scripts/sync_npm_to_adguard.py
@@ -2,6 +2,8 @@ import argparse
 import base64
 import json
 import os
+import subprocess
+import sys
 
 import requests
 
@@ -10,7 +12,13 @@ NPM_PROXY_PATH = "/opt/npm/data/nginx/proxy_host/"
 ADGUARD_HOST = "192.168.1.253"
 ADGUARD_PORT = "80"
 ADGUARD_USER = "root"
-ADGUARD_PASS = "redflower805"  # 🔒 replace with your actual password
+ADGUARD_PASS = os.environ.get("ADGUARD_PASSWORD") or subprocess.run(
+    ["infisical-get", "ADGUARD_ROOT_PASSWORD"],
+    capture_output=True, text=True, check=False,
+).stdout.strip()
+if not ADGUARD_PASS:
+    sys.stderr.write("ERROR: ADGUARD_PASSWORD not set and infisical-get failed.\n")
+    sys.exit(1)
 ADGUARD_TARGET_IP = "192.168.1.95"  # NPM IP for internal rewrites
 
 API_BASE = f"http://{ADGUARD_HOST}:{ADGUARD_PORT}/control"


### PR DESCRIPTION
## Summary

Removes the shared admin password literal `redflower805` from three tracked files. Pulls the password from Infisical (`ADGUARD_ROOT_PASSWORD`) at runtime instead.

## Background

The literal was effectively a no-op until 2026-05-08 — AdGuard at 192.168.1.224 ran with `users: []` and ignored all auth headers (operations bead #1083). homelab-iac PR #42 enforced auth via a templated `users:` block sourced from Infisical. Operations worktree commit `d01cae4` and homelab-gitops PR #114 scrubbed the literal from the active scripts in those repos. This PR closes the loop on the parent mcp-servers repo.

The two scripts target the AdGuard **replica** (192.168.1.253), which is still auth-less today. But `redflower805` was a shared credential reused for AdGuard root, MQTT broker, WiFi PSK, several SSH passwords — keeping it in tracked code is a continuing audit hygiene problem regardless of functional impact.

## Changes

- **`scripts/generate_adguard_rewrites_from_sqlite.py`**: replaces literal with module-level resolver: prefer `ADGUARD_PASSWORD` env var, fall back to `subprocess.run(['infisical-get', 'ADGUARD_ROOT_PASSWORD'])`, fail-fast with helpful error.
- **`scripts/sync_npm_to_adguard.py`**: same pattern, terser.
- **`docs/network/ADGUARD_DNS_UPDATE_PROCEDURES.md`**: replaces 6 instances of `-u "root:redflower805"` with `-u "root:$(infisical-get ADGUARD_ROOT_PASSWORD)"` in example curl commands.

## Test plan

- [x] Both Python files parse (`python3 -c "import ast; ast.parse(...)"`)
- [x] `redflower805` literal count is now 0 in all three files
- [ ] Run the audit script end-to-end after merge (deferred — not blocking)
- [ ] Verify documented commands work as written

## References

- Operations bead [#1053](https://vikunja.internal.lakehouse.wtf/tasks/1053) — Task 2 of monorepo-security-remediation
- Operations bead [#1083](https://vikunja.internal.lakehouse.wtf/tasks/1083) — AdGuard auth gap (CLOSED)
- Operations bead [#1080](https://vikunja.internal.lakehouse.wtf/tasks/1080) — Task 21B (history scrub for this repo)
- homelab-iac PR [#42](https://github.com/festion/homelab-iac/pull/42) — IaC change enforcing AdGuard auth
- homelab-gitops PR [#114](https://github.com/festion/homelab-gitops/pull/114) — sibling scrub for homelab-gitops

🤖 Generated with [Claude Code](https://claude.com/claude-code)