### PR TITLE
security: scrub HA Token B from serena memories

### DIFF
--- a/.serena/memories/home_assistant_entity_cleanup_september_2025.md
+++ b/.serena/memories/home_assistant_entity_cleanup_september_2025.md
@@ -73,7 +73,7 @@ Successfully removed 18 phantom entities from entity registry:
 ```
 
 ### Authentication Token Management
-- **Production Token**: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI5YTAyYzMxZTNkYjM0YmQxYTQ2YzNlMmJhZDExMjI3NCIsImlhdCI6MTc0NzUwODk4OSwiZXhwIjoyMDYyODY4OTg5fQ.BwOQMlSgBOi7kb2IwgSIK4KCRDe2mI-sJL496NUwHkE`
+- **Production Token**: `<see Infisical: homelab-gitops/prod/HA_LONG_LIVED_TOKEN — old Token B revoked 2026-05>`
 - **Note**: Token changes after system reboots, requires retrieval from user
 
 ## Final System State

--- a/.serena/memories/home_assistant_production_access_credentials.md
+++ b/.serena/memories/home_assistant_production_access_credentials.md
@@ -6,11 +6,11 @@
 - **Config Directory**: `/config/` (maps to local `/home/dev/workspace/home-assistant-config/`)
 
 ## Long-Lived Access Token
-**Current Token**: `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI5YTAyYzMxZTNkYjM0YmQxYTQ2YzNlMmJhZDExMjI3NCIsImlhdCI6MTc0NzUwODk4OSwiZXhwIjoyMDYyODY4OTg5fQ.BwOQMlSgBOi7kb2IwgSIK4KCRDe2mI-sJL496NUwHkE`
+**Current Token**: `${HA_LONG_LIVED_TOKEN}`
 
 **Usage**: 
 ```bash
-HA_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI5YTAyYzMxZTNkYjM0YmQxYTQ2YzNlMmJhZDExMjI3NCIsImlhdCI6MTc0NzUwODk4OSwiZXhwIjoyMDYyODY4OTg5fQ.BwOQMlSgBOi7kb2IwgSIK4KCRDe2mI-sJL496NUwHkE"
+HA_TOKEN="${HA_LONG_LIVED_TOKEN}"
 curl -H "Authorization: Bearer $HA_TOKEN" "http://192.168.1.155:8123/api/states/sensor.unavailable_entities"
 ```
 


### PR DESCRIPTION
Removes 3 dead HA long-lived JWT literals (Token B, iss 9a02c31e — already revoked in HA) from 2 serena memory files. Sibling PRs: festion/home-assistant-config#40, festion/homelab-gitops#116. References: operations bead #1059. 🤖 Generated with [Claude Code](https://claude.com/claude-code)