### PR TITLE
security: scrub Uptime Kuma password from docs (Task 4)

### DIFF
--- a/docs/UPTIME_KUMA_MONITORS_ADDED.md
+++ b/docs/UPTIME_KUMA_MONITORS_ADDED.md
@@ -51,7 +51,7 @@ ssh root@192.168.1.137 "pct push 132 /tmp/add-vikunja-memos-monitors.js /tmp/add
 ssh root@192.168.1.137 "pct exec 132 -- cp /tmp/add-vikunja-memos-monitors.js /opt/uptime-kuma/"
 
 # Execute script
-ssh root@192.168.1.137 "pct exec 132 -- bash -c 'cd /opt/uptime-kuma && node add-vikunja-memos-monitors.js root redflower805'"
+ssh root@192.168.1.137 "pct exec 132 -- bash -c 'cd /opt/uptime-kuma && node add-vikunja-memos-monitors.js root <see Infisical: homelab-gitops/prod/UPTIME_KUMA_ADMIN_PASSWORD>'"
 ```
 
 ### Execution Results
@@ -106,7 +106,7 @@ const socket = io('http://192.168.1.132:3001');
 ```javascript
 socket.emit('login', {
     username: 'root',
-    password: 'redflower805',
+    password: '<see Infisical: homelab-gitops/prod/UPTIME_KUMA_ADMIN_PASSWORD>',
     token: ''
 }, (res) => {
     if (res.ok) {
@@ -139,7 +139,7 @@ socket.emit('add', monitorConfig, (res) => {
 ### Web Interface
 - **URL:** https://uptime.internal.lakehouse.wtf
 - **Username:** root
-- **Password:** redflower805
+- **Password:** <see Infisical: homelab-gitops/prod/UPTIME_KUMA_ADMIN_PASSWORD>
 
 ### Viewing Monitors
 1. Navigate to https://uptime.internal.lakehouse.wtf


### PR DESCRIPTION
3-line scrub of redflower805 in docs/UPTIME_KUMA_MONITORS_ADDED.md. Live rotation done via Socket.IO changePassword. Sibling PRs: festion/proxmox-agent#19, festion/homelab-gitops#119. Operations bead #1055. 🤖 Generated with [Claude Code](https://claude.com/claude-code)