### PR TITLE
security(deps): clear all npm audit vulns in dashboard/ and api/

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -3183,9 +3183,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/api/package.json
+++ b/api/package.json
@@ -31,6 +31,7 @@
     "qs": "^6.14.2",
     "minimatch": "^10.2.1",
     "@tootallnate/once": "^3.0.1",
-    "brace-expansion": "^5.0.5"
+    "brace-expansion": "^5.0.5",
+    "ip-address": "^10.1.1"
   }
 }

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,7 +8,7 @@
       "name": "dashboard",
       "version": "1.0.4",
       "dependencies": {
-        "axios": "^1.13.5",
+        "axios": "^1.16.0",
         "lucide-react": "^0.509.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -36,7 +36,7 @@
         "eslint-plugin-react-refresh": "^0.4.5",
         "jest": "^30.0.2",
         "jest-environment-jsdom": "^30.0.2",
-        "postcss": "^8.4.32",
+        "postcss": "^8.5.14",
         "tailwindcss": "^3.3.6",
         "typescript": "~5.3.3",
         "typescript-eslint": "^8.38.0",
@@ -3695,12 +3695,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -7406,9 +7406,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -7424,6 +7424,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -11,7 +11,7 @@
     "tw:watch": "npx tailwindcss -i ./src/index.css -o ./src/generated.css --watch"
   },
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "lucide-react": "^0.509.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -45,7 +45,7 @@
     "eslint-plugin-react-refresh": "^0.4.5",
     "jest": "^30.0.2",
     "jest-environment-jsdom": "^30.0.2",
-    "postcss": "^8.4.32",
+    "postcss": "^8.5.14",
     "tailwindcss": "^3.3.6",
     "typescript": "~5.3.3",
     "typescript-eslint": "^8.38.0",


### PR DESCRIPTION
## Summary
- `dashboard/` axios `^1.13.5` → `^1.16.0` clears [GHSA-w9j2-pvgh-6h63](https://github.com/advisories/GHSA-w9j2-pvgh-6h63) (high — auth bypass via prototype pollution in `validateStatus` merge).
- `dashboard/` postcss `^8.4.32` → `^8.5.14` clears [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (moderate — XSS via unescaped `</style>` in CSS Stringify).
- `api/` adds `ip-address: ^10.1.1` to `overrides` to clear [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) (moderate — XSS in Address6 HTML-emitting methods). Transitive under `sqlite3 → node-gyp → make-fetch-happen → socks-proxy-agent → socks`. Resolves to `10.2.0` in lockfile; semver-compatible with `socks@2.8.7`.
- `npm audit` in `dashboard/` AND `api/` now reports 0 vulnerabilities.
- `dashboard/` `npm run build` succeeds. `api/` `npm test` passes (15/15).

## Test plan
- [x] `cd dashboard && npm audit` reports 0 vulnerabilities
- [x] `cd dashboard && npm run build` clean (tsc + vite build)
- [x] `cd api && npm audit` reports 0 vulnerabilities
- [x] `cd api && npm test` passes (15/15)
- [ ] CI checks pass on this branch (notably the previously-failing "Security and Dependencies Check" should now go green)

Closes Vikunja #1088 and Vikunja #1156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)