### PR TITLE
feat(vikunja-mcp): expose due_date and other writable fields

### DIFF
--- a/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/client.py
+++ b/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/client.py
@@ -56,13 +56,44 @@ class VikunjaClient:
 
     # --- Task operations ---
 
-    async def create_task(self, project_id: int, title: str, description: str = "", priority: int = 0) -> dict[str, Any]:
-        """Create a task in a project. Uses PUT."""
+    async def create_task(
+        self,
+        project_id: int,
+        title: str,
+        description: str = "",
+        priority: int = 0,
+        due_date: str | None = None,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        percent_done: float | None = None,
+        hex_color: str | None = None,
+        repeat_after: int | None = None,
+        repeat_mode: int | None = None,
+    ) -> dict[str, Any]:
+        """Create a task in a project. Uses PUT.
+
+        Date fields take RFC3339 strings (e.g. '2026-05-20T17:00:00Z').
+        Pass '0001-01-01T00:00:00Z' to leave a date unset on the server.
+        """
         body: dict[str, Any] = {"title": title}
         if description:
             body["description"] = description
         if priority:
             body["priority"] = priority
+        if due_date is not None:
+            body["due_date"] = due_date
+        if start_date is not None:
+            body["start_date"] = start_date
+        if end_date is not None:
+            body["end_date"] = end_date
+        if percent_done is not None:
+            body["percent_done"] = percent_done
+        if hex_color is not None:
+            body["hex_color"] = hex_color
+        if repeat_after is not None:
+            body["repeat_after"] = repeat_after
+        if repeat_mode is not None:
+            body["repeat_mode"] = repeat_mode
         resp = await self.client.put(f"/projects/{project_id}/tasks", json=body)
         resp.raise_for_status()
         return resp.json()

--- a/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/server.py
+++ b/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/server.py
@@ -93,6 +93,13 @@ async def vikunja_create_task(
     description: str = "",
     priority: int = 0,
     labels: list[str] | None = None,
+    due_date: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    percent_done: float | None = None,
+    hex_color: str | None = None,
+    repeat_after: int | None = None,
+    repeat_mode: int | None = None,
 ) -> dict[str, Any]:
     """Create a task in the active project.
 
@@ -101,6 +108,13 @@ async def vikunja_create_task(
         description: Task description (markdown supported).
         priority: 0=unset, 1=low, 2=medium, 3=high, 4=urgent, 5=do-now.
         labels: Optional list of label names (auto-created if they don't exist).
+        due_date: RFC3339 datetime (e.g. '2026-05-20T17:00:00Z'). Use '0001-01-01T00:00:00Z' to leave unset.
+        start_date: RFC3339 datetime.
+        end_date: RFC3339 datetime.
+        percent_done: Completion fraction 0.0-1.0.
+        hex_color: Hex color without '#' (e.g. 'ff9900').
+        repeat_after: Repeat interval in seconds.
+        repeat_mode: 0=after due/end, 1=monthly, 2=from-current-date.
     """
     project_id = require_project()
     client = get_client()
@@ -110,6 +124,13 @@ async def vikunja_create_task(
         title=title,
         description=description,
         priority=priority,
+        due_date=due_date,
+        start_date=start_date,
+        end_date=end_date,
+        percent_done=percent_done,
+        hex_color=hex_color,
+        repeat_after=repeat_after,
+        repeat_mode=repeat_mode,
     )
 
     if labels:
@@ -122,6 +143,7 @@ async def vikunja_create_task(
         "title": task["title"],
         "priority": task.get("priority", 0),
         "labels": labels or [],
+        "due_date": task.get("due_date", ""),
         "project": _active_project_name,
     }
 
@@ -152,6 +174,7 @@ async def vikunja_list_tasks(
             "title": t["title"],
             "priority": t.get("priority", 0),
             "done": t.get("done", False),
+            "due_date": t.get("due_date", ""),
             "labels": task_labels,
         })
 
@@ -180,6 +203,13 @@ async def vikunja_get_task(id: int) -> dict[str, Any]:
         "description": task.get("description", ""),
         "priority": task.get("priority", 0),
         "done": task.get("done", False),
+        "due_date": task.get("due_date", ""),
+        "start_date": task.get("start_date", ""),
+        "end_date": task.get("end_date", ""),
+        "percent_done": task.get("percent_done", 0),
+        "hex_color": task.get("hex_color", ""),
+        "repeat_after": task.get("repeat_after", 0),
+        "repeat_mode": task.get("repeat_mode", 0),
         "labels": [lb["title"] for lb in (task.get("labels") or [])],
         "comments": [
             {"id": c["id"], "text": c["comment"], "created": c.get("created", "")}
@@ -197,6 +227,13 @@ async def vikunja_update_task(
     description: str | None = None,
     priority: int | None = None,
     done: bool | None = None,
+    due_date: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    percent_done: float | None = None,
+    hex_color: str | None = None,
+    repeat_after: int | None = None,
+    repeat_mode: int | None = None,
 ) -> dict[str, Any]:
     """Update a task. Only provided fields are changed.
 
@@ -208,6 +245,13 @@ async def vikunja_update_task(
         description: New description (None = keep existing).
         priority: New priority 0-5 (None = keep existing).
         done: Mark as done/undone (None = keep existing).
+        due_date: RFC3339 datetime (e.g. '2026-05-20T17:00:00Z'). Pass '0001-01-01T00:00:00Z' to clear.
+        start_date: RFC3339 datetime.
+        end_date: RFC3339 datetime.
+        percent_done: Completion fraction 0.0-1.0.
+        hex_color: Hex color without '#' (e.g. 'ff9900'). Pass '' to clear.
+        repeat_after: Repeat interval in seconds (0 = no repeat).
+        repeat_mode: 0=after due/end, 1=monthly, 2=from-current-date.
     """
     client = get_client()
     changes: dict[str, Any] = {}
@@ -219,6 +263,20 @@ async def vikunja_update_task(
         changes["priority"] = priority
     if done is not None:
         changes["done"] = done
+    if due_date is not None:
+        changes["due_date"] = due_date
+    if start_date is not None:
+        changes["start_date"] = start_date
+    if end_date is not None:
+        changes["end_date"] = end_date
+    if percent_done is not None:
+        changes["percent_done"] = percent_done
+    if hex_color is not None:
+        changes["hex_color"] = hex_color
+    if repeat_after is not None:
+        changes["repeat_after"] = repeat_after
+    if repeat_mode is not None:
+        changes["repeat_mode"] = repeat_mode
 
     task = await client.update_task(id, **changes)
 
@@ -227,6 +285,13 @@ async def vikunja_update_task(
         "title": task["title"],
         "priority": task.get("priority", 0),
         "done": task.get("done", False),
+        "due_date": task.get("due_date", ""),
+        "start_date": task.get("start_date", ""),
+        "end_date": task.get("end_date", ""),
+        "percent_done": task.get("percent_done", 0),
+        "hex_color": task.get("hex_color", ""),
+        "repeat_after": task.get("repeat_after", 0),
+        "repeat_mode": task.get("repeat_mode", 0),
         "updated": task.get("updated", ""),
     }
 

--- a/mcp-servers/vikunja-mcp-server/tests/test_client.py
+++ b/mcp-servers/vikunja-mcp-server/tests/test_client.py
@@ -108,6 +108,81 @@ async def test_create_task(client):
 
 
 @pytest.mark.asyncio
+async def test_create_task_with_dates_and_recurrence(client):
+    """Optional date / recurrence / color fields only appear in the body when supplied."""
+    mock_response = _make_response(200, {"id": 43, "title": "Pay rent"})
+    client.client = AsyncMock()
+    client.client.put = AsyncMock(return_value=mock_response)
+
+    await client.create_task(
+        5,
+        "Pay rent",
+        due_date="2026-06-01T17:00:00Z",
+        start_date="2026-05-25T00:00:00Z",
+        end_date="2026-06-01T17:00:00Z",
+        percent_done=0.0,
+        hex_color="ff9900",
+        repeat_after=2592000,
+        repeat_mode=1,
+    )
+
+    client.client.put.assert_called_once_with(
+        "/projects/5/tasks",
+        json={
+            "title": "Pay rent",
+            "due_date": "2026-06-01T17:00:00Z",
+            "start_date": "2026-05-25T00:00:00Z",
+            "end_date": "2026-06-01T17:00:00Z",
+            "percent_done": 0.0,
+            "hex_color": "ff9900",
+            "repeat_after": 2592000,
+            "repeat_mode": 1,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_task_omits_unset_fields(client):
+    """None values for optional fields are skipped (server keeps its defaults)."""
+    mock_response = _make_response(200, {"id": 44, "title": "Quick task"})
+    client.client = AsyncMock()
+    client.client.put = AsyncMock(return_value=mock_response)
+
+    await client.create_task(5, "Quick task")
+
+    client.client.put.assert_called_once_with(
+        "/projects/5/tasks",
+        json={"title": "Quick task"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_task_sets_due_date(client):
+    """update_task should pass due_date through the read-modify-write merge."""
+    existing_task = {
+        "id": 42, "title": "Fix the thing", "description": "It's broken",
+        "priority": 3, "done": False, "project_id": 5,
+        "labels": [], "due_date": "0001-01-01T00:00:00Z",
+    }
+    get_response = _make_response(200, existing_task)
+    updated_task = {**existing_task, "due_date": "2026-06-01T17:00:00Z"}
+    post_response = _make_response(200, updated_task)
+
+    client.client = AsyncMock()
+    client.client.get = AsyncMock(return_value=get_response)
+    client.client.post = AsyncMock(return_value=post_response)
+
+    result = await client.update_task(42, due_date="2026-06-01T17:00:00Z")
+
+    posted_body = client.client.post.call_args[1]["json"]
+    assert posted_body["due_date"] == "2026-06-01T17:00:00Z"
+    # Other existing fields are preserved (read-modify-write invariant)
+    assert posted_body["title"] == "Fix the thing"
+    assert posted_body["description"] == "It's broken"
+    assert result["due_date"] == "2026-06-01T17:00:00Z"
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_open(client):
     mock_response = _make_response(200, [
         {"id": 1, "title": "Open task", "done": False},


### PR DESCRIPTION
## Summary
- Adds optional `due_date`, `start_date`, `end_date`, `percent_done`, `hex_color`, `repeat_after`, `repeat_mode` to `vikunja_create_task` and `vikunja_update_task`
- Surfaces the new fields in `vikunja_get_task` responses and adds `due_date` to `vikunja_list_tasks` rows
- Existing read-modify-write merge in `client.update_task` already passes through arbitrary changes — only the MCP tool surface and `client.create_task` needed extending
- Closes Vikunja #1266

## Field conventions
- Date fields take RFC3339 strings (`'2026-06-01T17:00:00Z'`); pass `'0001-01-01T00:00:00Z'` to clear
- `hex_color` is the hex value without `'#'`; `''` clears
- All new params default to `None` (don't change), matching the existing pattern

## Test plan
- [x] `pytest tests/test_client.py` — 22/22 pass (3 new tests for date/recurrence/clear behaviors)
- [x] `pytest tests/test_integration.py` — full lifecycle still passes against live Vikunja
- [x] Live round-trip smoke: create with all new fields → update due_date → clear via zero-time string → delete. All correct on prod Vikunja at 192.168.1.143.
- [ ] After merge: restart Claude Code MCP layer so the new tool signatures take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)