### PR TITLE
docs(vikunja-mcp): note description/comment accept raw HTML, not markdown

### DIFF
--- a/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/server.py
+++ b/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/server.py
@@ -105,7 +105,7 @@ async def vikunja_create_task(
 
     Args:
         title: Task title (required).
-        description: Task description (markdown supported).
+        description: Task description. Accepts raw HTML (e.g. <br>, <b>, <code>, <pre>); markdown is NOT interpreted. Do not pre-escape — escaped tags like &lt;br&gt; render as literal text. NOTE: avoid raw <parameter name="...">...</parameter> substrings in this field; the create-task XML marshaller silently drops the typed `priority` arg when present (see vikunja-mcp #1342). HTML-escape those specific tags only.
         priority: 0=unset, 1=low, 2=medium, 3=high, 4=urgent, 5=do-now.
         labels: Optional list of label names (auto-created if they don't exist).
         due_date: RFC3339 datetime (e.g. '2026-05-20T17:00:00Z'). Use '0001-01-01T00:00:00Z' to leave unset.
@@ -242,7 +242,7 @@ async def vikunja_update_task(
     Args:
         id: Task ID.
         title: New title (empty string = keep existing).
-        description: New description (None = keep existing).
+        description: New description (None = keep existing). Accepts raw HTML (e.g. <br>, <b>, <code>, <pre>); markdown is NOT interpreted. Do not pre-escape — escaped tags like &lt;br&gt; render as literal text.
         priority: New priority 0-5 (None = keep existing).
         done: Mark as done/undone (None = keep existing).
         due_date: RFC3339 datetime (e.g. '2026-05-20T17:00:00Z'). Pass '0001-01-01T00:00:00Z' to clear.
@@ -314,7 +314,7 @@ async def vikunja_add_comment(task_id: int, comment: str) -> dict[str, Any]:
 
     Args:
         task_id: Task ID.
-        comment: Comment text.
+        comment: Comment text. Accepts raw HTML (e.g. <br>, <b>, <code>, <pre>); markdown is NOT interpreted. Do not pre-escape — escaped tags like &lt;br&gt; render as literal text instead of a line break.
     """
     client = get_client()
     result = await client.add_comment(task_id, comment)


### PR DESCRIPTION
## Summary
- Update docstrings for `vikunja_create_task`, `vikunja_update_task`, and `vikunja_add_comment` to state that the `description`/`comment` arguments accept raw HTML (not markdown). The prior text either claimed "markdown supported" (wrong) or said nothing — both pushed LLM callers toward defensively HTML-escaping their input, which Vikunja then stores verbatim and renders as literal `<br>` text.
- The `create_task` description note also cross-references the `<parameter>`-tag marshalling gotcha tracked separately as #1342, since both bugs surface in the same field.

## Why
Caught on 2026-05-16 while commenting on proxmox-agent tasks #1338 / #1339 — pre-escaped line breaks landed as the literal characters `<br>` in the rendered comment. Schema docs are the cheapest place to prevent recurrence (LLM callers see the description in the tool schema and adjust before sending).

Tracked as Vikunja #1343 (operations project — internal task tracker, not a GH issue).

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('src/vikunja_mcp/server.py').read())"` — syntax valid.
- [ ] After merge: restart Claude Code's vikunja-mcp instance (`claude mcp restart vikunja` or session restart) and confirm the new descriptions surface in the tool schema.
- [ ] Spot-check by creating a test task whose description uses raw `<br>` / `<b>` tags and visually confirming Vikunja UI renders correctly (already validated via earlier task creations; this PR is doc-only and changes no runtime behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)