### PR TITLE
fix(vikunja-mcp): strip leaked <parameter> tags at MCP boundary

### DIFF
--- a/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/sanitize.py
+++ b/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/sanitize.py
@@ -1,0 +1,58 @@
+"""Defensive input sanitization for caller-supplied text fields.
+
+See vikunja-mcp #1342: Claude Code's tool-call XML marshaller silently drops
+typed parameters (e.g. `priority`) when the surrounding description string
+contains a raw `<parameter name="...">...</parameter>` substring. The
+description ends up with the leaked tag appended, and the typed field
+defaults silently (priority=0, done=false, etc.).
+
+This module detects the leak fingerprint at the MCP-server entry point and
+strips it, logging a WARNING so the recurrence is visible to operators
+without blocking the create/update call.
+"""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# Matches the leak fingerprints observed on 2026-05-16:
+#   <parameter name="priority">3</parameter>           (fully closed)
+#   <parameter name="priority">3                       (no closing tag)
+#   </description>\n<parameter name="priority">3       (with description prefix)
+# Both the </description> prefix and the </parameter> suffix are optional;
+# the value group [^<]* stops at the next tag boundary or end-of-string.
+_PARAM_LEAK_RE = re.compile(
+    r'(?:</?description>\s*)?'
+    r'<parameter\s+name="([a-zA-Z_][a-zA-Z0-9_]*)">'
+    r'([^<]*)'
+    r'(?:</parameter>)?',
+)
+
+
+def strip_param_leak(text: str | None, field: str) -> str | None:
+    """Strip leaked `<parameter name="X">V</parameter>` tags from `text`.
+
+    Returns the cleaned string with each match removed and trailing
+    whitespace stripped. Returns the input unchanged when it is None,
+    empty, or contains no matches. Each stripped tag emits a WARNING log
+    line naming the field, leaked parameter, and value.
+
+    Args:
+        text: Caller-supplied description or comment body.
+        field: Label used in the log message (e.g. "description",
+            "comment"). Purely cosmetic.
+    """
+    if not text:
+        return text
+
+    def _capture(m: re.Match) -> str:
+        logger.warning(
+            "%s: stripped leaked <parameter name=%r> tag (value=%r) "
+            "— probable caller XML-serialization bug; see vikunja-mcp #1342",
+            field, m.group(1), m.group(2),
+        )
+        return ""
+
+    cleaned = _PARAM_LEAK_RE.sub(_capture, text).rstrip()
+    return cleaned

--- a/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/server.py
+++ b/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/server.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 from mcp.server.fastmcp import FastMCP
 from vikunja_mcp.client import VikunjaClient
+from vikunja_mcp.sanitize import strip_param_leak
 
 logging.basicConfig(
     level=logging.INFO,
@@ -118,6 +119,8 @@ async def vikunja_create_task(
     """
     project_id = require_project()
     client = get_client()
+
+    description = strip_param_leak(description, "description") or ""
 
     task = await client.create_task(
         project_id=project_id,
@@ -258,7 +261,7 @@ async def vikunja_update_task(
     if title:
         changes["title"] = title
     if description is not None:
-        changes["description"] = description
+        changes["description"] = strip_param_leak(description, "description")
     if priority is not None:
         changes["priority"] = priority
     if done is not None:
@@ -317,6 +320,7 @@ async def vikunja_add_comment(task_id: int, comment: str) -> dict[str, Any]:
         comment: Comment text.
     """
     client = get_client()
+    comment = strip_param_leak(comment, "comment") or ""
     result = await client.add_comment(task_id, comment)
     return {
         "comment_id": result["id"],

--- a/mcp-servers/vikunja-mcp-server/tests/test_sanitize.py
+++ b/mcp-servers/vikunja-mcp-server/tests/test_sanitize.py
@@ -1,0 +1,85 @@
+"""Tests for vikunja_mcp.sanitize: defensive `<parameter>`-tag stripping."""
+
+import logging
+
+from vikunja_mcp.sanitize import strip_param_leak
+
+
+def test_returns_none_unchanged():
+    assert strip_param_leak(None, "description") is None
+
+
+def test_returns_empty_unchanged():
+    assert strip_param_leak("", "description") == ""
+
+
+def test_passes_through_clean_text():
+    text = "A description with no leak. Has <b>bold</b> and <code>code</code>."
+    assert strip_param_leak(text, "description") == text
+
+
+def test_strips_fully_closed_tag(caplog):
+    text = 'Body text.<parameter name="priority">3</parameter>'
+    with caplog.at_level(logging.WARNING):
+        result = strip_param_leak(text, "description")
+    assert result == "Body text."
+    assert "priority" in caplog.text
+    assert "'3'" in caplog.text
+
+
+def test_strips_unclosed_tag(caplog):
+    # The most common observed fingerprint: trailing param, no closing tag.
+    text = 'Body text.\n<parameter name="priority">3'
+    with caplog.at_level(logging.WARNING):
+        result = strip_param_leak(text, "description")
+    assert result == "Body text."  # trailing whitespace stripped
+
+
+def test_strips_with_description_prefix(caplog):
+    text = 'Body text.</description>\n<parameter name="priority">3</parameter>'
+    with caplog.at_level(logging.WARNING):
+        result = strip_param_leak(text, "description")
+    assert result == "Body text."
+
+
+def test_strips_multiple_leaks(caplog):
+    text = 'A<parameter name="priority">3</parameter>B<parameter name="done">true</parameter>'
+    with caplog.at_level(logging.WARNING):
+        result = strip_param_leak(text, "description")
+    assert result == "AB"
+    assert "priority" in caplog.text
+    assert "done" in caplog.text
+
+
+def test_ignores_html_escaped_parameter_tags():
+    # Callers documenting the gotcha use escaped form — must be preserved verbatim.
+    text = "Avoid raw &lt;parameter name=&quot;X&quot;&gt; tags in descriptions."
+    assert strip_param_leak(text, "description") == text
+
+
+def test_ignores_similar_unmatching_tags():
+    text = "Some <param>bad</param> and <parameters>worse</parameters> tags."
+    assert strip_param_leak(text, "description") == text
+
+
+def test_warning_includes_field_label(caplog):
+    text = 'X<parameter name="priority">3</parameter>'
+    with caplog.at_level(logging.WARNING):
+        strip_param_leak(text, "comment")
+    assert "comment" in caplog.text
+
+
+def test_no_warning_for_clean_text(caplog):
+    text = "Just normal text with <b>tags</b>."
+    with caplog.at_level(logging.WARNING):
+        strip_param_leak(text, "description")
+    assert caplog.records == []
+
+
+def test_strips_labels_value_with_brackets(caplog):
+    # labels is JSON-shaped; the value contains [", ", ] but no '<'.
+    text = 'Body.<parameter name="labels">["bug","docs"]</parameter>'
+    with caplog.at_level(logging.WARNING):
+        result = strip_param_leak(text, "description")
+    assert result == "Body."
+    assert "labels" in caplog.text


### PR DESCRIPTION
## Summary
- Add `vikunja_mcp.sanitize.strip_param_leak()` — regex-based detector for `<parameter name="...">V</parameter>` substrings in description/comment fields, with WARNING log on every hit.
- Apply at the entry of `vikunja_create_task` (description), `vikunja_update_task` (description), and `vikunja_add_comment` (comment).
- HTML-escaped variants (`&lt;parameter&gt;`) are deliberately preserved — that's the documented caller workaround for the underlying serializer bug.

## Why
Claude Code's tool-call XML marshaller silently drops typed parameters (priority, done, labels, etc.) when a surrounding description string contains a raw `<parameter name="...">...</parameter>` substring. Observed 4-for-4 on tasks #1338, #1339, #1341, and #1342 itself in the operations Vikunja project on 2026-05-16. The description ends up with the leaked tag appended, and the typed field defaults silently — no error raised on either end.

This defensive transform is the option-1 recommendation from Vikunja #1342 (operations project). The optional polish (attempt to recover the typed field from the parsed value) is deferred — the WARNING log already surfaces the bug for caller-side fix, which is the primary value.

## Test plan
- [x] `pytest tests/test_sanitize.py` — 12 new tests, all pass. Coverage: fully-closed tag, unclosed tag, `</description>` prefix, multiple leaks, HTML-escaped (negative), similar-but-unmatching tags (negative), clean text (negative), labels JSON value, None/empty input, warning field-label routing.
- [x] `pytest` — full suite: 35/35 pass (12 new + 23 existing).
- [x] Python syntax check passes.
- [ ] After merge + MCP restart: create a task with raw `<parameter name="priority">3</parameter>` substring in the description; confirm the description is cleaned and a WARNING line lands in the MCP server log.

## Notes
- The fix only changes behavior for inputs containing the leak fingerprint — clean descriptions/comments pass through untouched and emit no log.
- Sister PR #34 (#1343) updates the tool docstrings to explain that `description`/`comment` accept raw HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)