### PR TITLE
fix(vikunja-mcp): return ground-truth priority/labels from create_task (#1526)

### DIFF
--- a/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/server.py
+++ b/mcp-servers/vikunja-mcp-server/src/vikunja_mcp/server.py
@@ -106,7 +106,7 @@ async def vikunja_create_task(
 
     Args:
         title: Task title (required).
-        description: Task description. Accepts raw HTML (e.g. <br>, <b>, <code>, <pre>); markdown is NOT interpreted. Do not pre-escape — escaped tags like &lt;br&gt; render as literal text. NOTE: avoid raw <parameter name="...">...</parameter> substrings in this field; the create-task XML marshaller silently drops the typed `priority` arg when present (see vikunja-mcp #1342). HTML-escape those specific tags only.
+        description: Task description. Accepts raw HTML (e.g. <br>, <b>, <code>, <pre>); markdown is NOT interpreted. Do not pre-escape — escaped tags like &lt;br&gt; render as literal text. NOTE: avoid raw <parameter name="...">...</parameter> substrings in this field; the CALLER's tool-call serializer (client-side, not this server) can silently drop the typed `priority`/`labels` args when present (see vikunja-mcp #1342/#1526). HTML-escape those specific tags only. The returned `priority`/`labels` are read back from Vikunja (ground truth, not the requested values); a `warnings` list is included if what was stored differs from what was requested.
         priority: 0=unset, 1=low, 2=medium, 3=high, 4=urgent, 5=do-now.
         labels: Optional list of label names (auto-created if they don't exist).
         due_date: RFC3339 datetime (e.g. '2026-05-20T17:00:00Z'). Use '0001-01-01T00:00:00Z' to leave unset.
@@ -141,14 +141,41 @@ async def vikunja_create_task(
             label = await client.get_or_create_label(label_name)
             await client.attach_label(task["id"], label["id"])
 
-    return {
+    # Return GROUND TRUTH, not what was requested. The headline "silent drop"
+    # (#1526) happens upstream in the caller's tool-call serialization — when
+    # priority/labels never reach this server they can't be recovered here —
+    # but we can (a) report what Vikunja actually stored by reading the task
+    # back, and (b) warn when it differs from what we received. That covers
+    # label-attach failures and any genuine server-side drop, so the return
+    # value never claims success it can't substantiate.
+    final = await client.get_task(task["id"])
+    stored_priority = final.get("priority", 0)
+    attached_labels = [lb["title"] for lb in (final.get("labels") or [])]
+
+    warnings: list[str] = []
+    if priority and stored_priority != priority:
+        warnings.append(
+            f"requested priority={priority} but Vikunja stored priority={stored_priority}"
+        )
+    if labels:
+        attached_lower = {lb.lower() for lb in attached_labels}
+        missing = [lb for lb in labels if lb.lower() not in attached_lower]
+        if missing:
+            warnings.append(f"requested labels not attached: {missing}")
+
+    result: dict[str, Any] = {
         "task_id": task["id"],
-        "title": task["title"],
-        "priority": task.get("priority", 0),
-        "labels": labels or [],
-        "due_date": task.get("due_date", ""),
+        "title": final.get("title", task["title"]),
+        "priority": stored_priority,
+        "labels": attached_labels,
+        "due_date": final.get("due_date", ""),
         "project": _active_project_name,
     }
+    if warnings:
+        for w in warnings:
+            logger.warning("create_task: %s", w)
+        result["warnings"] = warnings
+    return result
 
 
 @mcp.tool()

--- a/mcp-servers/vikunja-mcp-server/tests/test_server.py
+++ b/mcp-servers/vikunja-mcp-server/tests/test_server.py
@@ -1,0 +1,92 @@
+"""Tests for server-level tool behavior (vikunja-mcp #1526).
+
+vikunja_create_task must return GROUND TRUTH — the priority/labels actually
+persisted by Vikunja, read back after the write — not the values that were
+requested. When they differ (an upstream serialization drop, or a label that
+failed to attach), it must surface a `warnings` entry instead of silently
+reporting success.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+import vikunja_mcp.server as server
+
+
+def _mock_client(create_resp, get_resp, label_id=7):
+    """Build an AsyncMock VikunjaClient for the create_task path."""
+    client = AsyncMock()
+    client.create_task = AsyncMock(return_value=create_resp)
+    client.get_or_create_label = AsyncMock(
+        side_effect=lambda name: {"id": label_id, "title": name}
+    )
+    client.attach_label = AsyncMock(return_value={"ok": True})
+    client.get_task = AsyncMock(return_value=get_resp)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _active_project():
+    """Pretend a project is active for the duration of each test."""
+    server._active_project_id = 5
+    server._active_project_name = "test-project"
+    yield
+    server._active_project_id = None
+    server._active_project_name = None
+
+
+@pytest.mark.asyncio
+async def test_return_reflects_actually_attached_labels_not_requested():
+    """If a requested label did NOT end up attached, the return must report
+    the real (empty) label set and warn — never echo the request as success."""
+    create_resp = {"id": 42, "title": "T", "priority": 3}
+    # Ground truth read-back: label never actually attached.
+    get_resp = {"id": 42, "title": "T", "priority": 3, "labels": [], "due_date": ""}
+    client = _mock_client(create_resp, get_resp)
+
+    with patch.object(server, "get_client", return_value=client):
+        result = await server.vikunja_create_task(
+            title="T", priority=3, labels=["bug"]
+        )
+
+    assert result["labels"] == []  # ground truth, NOT ["bug"]
+    assert "warnings" in result
+    assert any("bug" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_warns_when_stored_priority_differs_from_requested():
+    """If Vikunja stored a different priority than requested, return the
+    stored value and warn (catches genuine server-side drops)."""
+    create_resp = {"id": 42, "title": "T", "priority": 0}
+    get_resp = {"id": 42, "title": "T", "priority": 0, "labels": [], "due_date": ""}
+    client = _mock_client(create_resp, get_resp)
+
+    with patch.object(server, "get_client", return_value=client):
+        result = await server.vikunja_create_task(title="T", priority=3)
+
+    assert result["priority"] == 0  # ground truth, NOT the requested 3
+    assert "warnings" in result
+    assert any("priority" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_clean_create_has_no_warnings():
+    """When everything persisted as requested, return ground truth and no
+    warnings key."""
+    create_resp = {"id": 42, "title": "T", "priority": 3}
+    get_resp = {
+        "id": 42, "title": "T", "priority": 3,
+        "labels": [{"title": "bug"}], "due_date": "",
+    }
+    client = _mock_client(create_resp, get_resp)
+
+    with patch.object(server, "get_client", return_value=client):
+        result = await server.vikunja_create_task(
+            title="T", priority=3, labels=["bug"]
+        )
+
+    assert result["task_id"] == 42
+    assert result["priority"] == 3
+    assert result["labels"] == ["bug"]
+    assert "warnings" not in result


### PR DESCRIPTION
## Summary

`vikunja_create_task` reported the **requested** labels (`labels or []`) rather than the labels actually attached — claiming success it could not substantiate. After create+attach it now **re-reads the task** and returns the priority/labels Vikunja actually stored, plus a `warnings` list (also logged) when the stored values differ from what was requested.

## Root cause (#1526)

The headline "silent drop" of `priority`/`labels` on create has two distinct sources:

- **`<parameter>`-substring trigger (#1342):** caller-side tool-call serialization mangles the description; already handled by `sanitize.py` (unchanged here).
- **Flaky no-`<parameter>` drop:** this is *also* caller-side (the Claude Code harness's tool-call serialization), **not** this server. Exercising the server's own code path **without the harness** created **15/15** tasks with `priority`+`labels` intact, zero drops. When a typed arg is dropped upstream, the function receives the Python default and correctly omits it — the server cannot recover an arg it never received.

So this PR does **not** (and cannot) recover a harness-dropped arg. What it fixes is the one genuine server-side defect: the return value lying about labels. The tool now returns ground truth and surfaces any real discrepancy instead of hiding it.

## Changes

- `server.py` — `vikunja_create_task` re-reads the task post-create and returns actual stored `priority` + attached `labels`; adds `warnings` (+ log) on mismatch; docstring corrected to attribute the drop to caller-side serialization.
- `tests/test_server.py` (new) — 3 cases: ground-truth labels, priority-drop warning, clean path (no `warnings` key).

## Verification

- Watched the 2 behavior tests fail RED before implementing, then pass.
- Full suite **37/37 green**, no regressions.
- Live end-to-end: create → attach → readback → `priority=3, labels=["bug"]`, no warnings on clean path; task deleted.

## Note

The running MCP server must respawn (`/clear` or restart) to pick up this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)