### PR TITLE
fix(dashboard): bump transitive ws to ^8.20.1 (clears moderate audit vuln)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -9109,10 +9109,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,7 +23,8 @@
     "flatted": "^3.4.2",
     "brace-expansion": "^2.0.3",
     "yaml": "^2.8.3",
-    "follow-redirects": "^1.16.0"
+    "follow-redirects": "^1.16.0",
+    "ws": "^8.20.1"
   },
   "devDependencies": {
     "@eslint/js": "^8.56.0",


### PR DESCRIPTION
## Summary

The `gitops-audit` **Security and Dependencies Check** job runs `npm audit --audit-level=moderate` in `dashboard/` and `api/`. It fails on a moderate vuln in transitive **`ws@8.18.2`** in `dashboard/`:

- `ws`: *Uninitialized memory disclosure* — [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx), affects `>=8.0.0 <8.20.1`.
- `ws` enters via `jest-environment-jsdom → jsdom` (a devDependency chain) — purely transitive.

## Fix

Add `ws: "^8.20.1"` to dashboard's **existing `overrides` block** (the established pattern in this package.json), forcing `ws@8.21.0`. An override is the correct tool for a purely-transitive vuln — no `npm audit fix --force`.

## Verification

In `dashboard/`:
- `npm audit --audit-level=moderate` → **0 vulnerabilities** (was: 1 moderate)
- `npm ci` stays in sync with the updated lockfile
- ws chain now resolves to `8.21.0`

`api/` already audits clean (0 vulns) and is untouched. The root `package.json` (untracked / gitignored lockfile) is not involved — the CI job only audits `dashboard/` and `api/`.

## Scope

Two files: `dashboard/package.json` (+1 override line) and `dashboard/package-lock.json` (ws 8.18.2 → 8.21.0). Unblocks the Security check on all PRs against this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)