### PR TITLE
ci: bump Node-20 actions to Node-24-compatible versions before 2026-06-16 deprecation

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,7 +32,7 @@ jobs:
           }
 
       - name: Upload audit report as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: daily-audit-report
           path: output/GitRepoReport.md

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload quality report as artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: code-quality-report
           path: output/CodeQualityReport.md

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
         tar -czf homelab-gitops-auditor-${{ github.sha }}.tar.gz -C deploy-staging .
     
     - name: Upload deployment artifact
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: deployment-package-${{ github.sha }}
         path: homelab-gitops-auditor-${{ github.sha }}.tar.gz
@@ -84,7 +84,7 @@ jobs:
     
     - name: Create GitHub release (on tag)
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ github.ref_name }}
         name: Release ${{ github.ref_name }}

--- a/.github/workflows/gitops-audit.yml
+++ b/.github/workflows/gitops-audit.yml
@@ -93,7 +93,7 @@ jobs:
           bash scripts/comprehensive_audit.sh --dev
 
       - name: Upload audit results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: audit-report
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Download audit results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: audit-report
           path: audit-history/

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -62,13 +62,13 @@ jobs:
     
     - name: Run CodeQL Analysis
       if: github.event_name != 'schedule'
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: javascript
     
     - name: Perform CodeQL Analysis
       if: github.event_name != 'schedule'
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
     
     - name: Scan shell scripts with ShellCheck
       run: |

--- a/.github/workflows/weekly_audit_email.yml
+++ b/.github/workflows/weekly_audit_email.yml
@@ -69,7 +69,7 @@ jobs:
           "HTML_BODY<<EOF`n$body`nEOF" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Send audit summary email
-        uses: dawidd6/action-send-mail@v3
+        uses: dawidd6/action-send-mail@v17
         with:
           server_address: smtp.gmail.com
           server_port: 587


### PR DESCRIPTION
Bumps every Node-20 action pin in `.github/workflows/` ahead of GitHub forcing Node 24 on **2026-06-16** (Node 20 removed from runners 2026-09-16). Version pins only — no job logic changes.

| Action | Before → After |
|---|---|
| `actions/upload-artifact` | v5 → v7 |
| `actions/download-artifact` | v5 → v8 |
| `github/codeql-action` (init+analyze) | v3 → v4 |
| `softprops/action-gh-release` | v2 → v3 |
| `dawidd6/action-send-mail` | v3 → v17 (the 8 inputs used are identical across versions) |

Each bump verified against the action's `action.yml` `runs.using` at the exact tag.

**Authored by stormcrow** (dispatch `dispatch-azr`, Vikunja #1598): the agent completed and verified this work in its sandbox 3× but couldn't push (App repo access → workflows-write permission → push-credential wiring, fixed in sequence; the last is tracked as a stormcrow bug). Commit `5dfb8aa8e` is the bot's own work, hand-carried over the wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)