### PR TITLE
fix(dashboard): bump react-router-dom to ^7.16.0 (clears high audit vulns)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -12,7 +12,7 @@
         "lucide-react": "^0.509.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^7.6.0",
+        "react-router-dom": "^7.16.0",
         "reactflow": "^11.11.4",
         "recharts": "^2.10.3"
       },
@@ -7700,9 +7700,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7722,12 +7722,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.0"
+        "react-router": "7.16.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,7 +15,7 @@
     "lucide-react": "^0.509.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.6.0",
+    "react-router-dom": "^7.16.0",
     "reactflow": "^11.11.4",
     "recharts": "^2.10.3"
   },


### PR DESCRIPTION
A fresh npm advisory (react-router 7.0.0–7.14.2 / react-router-dom ≤7.14.1, 2 high) is failing **Security and Dependencies Check** on every PR — discovered blocking #41. Direct-dependency bump within the existing `^7` major; `npm audit --audit-level=moderate` clean in `dashboard/` and `api/`, `npm ci` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)