### PR TITLE
security: remove live Proxmox token from version control (rotated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ omada_config_restore.cfg
 # .serena/memories/ are tracked deliberately; only project.yml is per-machine
 .serena/project.yml
 .beads/
+mcp-servers/proxmox-mcp-server/proxmox_mcp_config.json

--- a/mcp-servers/proxmox-mcp-server/proxmox_mcp_config.json.example
+++ b/mcp-servers/proxmox-mcp-server/proxmox_mcp_config.json.example
@@ -4,7 +4,7 @@
       "host": "proxmox.mgmt.lakehouse.wtf",
       "port": 8006,
       "username": "root",
-      "token": "PVEAPIToken=root@pam!mcp-server=969028e3-4df2-4cbf-866f-a66af4d2bb4e",
+      "token": "PVEAPIToken=root@pam!mcp-server=REPLACE_WITH_TOKEN_SECRET",
       "realm": "pam",
       "verify_ssl": false,
       "timeout": 30

--- a/mcp-servers/proxmox-mcp-server/test_token.py
+++ b/mcp-servers/proxmox-mcp-server/test_token.py
@@ -16,9 +16,13 @@ from proxmox_mcp.config import ProxmoxServerConfig
 async def test_token():
     """Test API token authentication."""
     
-    # Set token directly without shell parsing issues
-    token = "PVEAPIToken=root@pam!mcp-server=969028e3-4df2-4cbf-866f-a66af4d2bb4e"
-    
+    # Token must be supplied via env var — never hardcode a credential here.
+    token = os.environ.get("PROXMOX_MCP_TOKEN", "")
+    if not token:
+        print("Set PROXMOX_MCP_TOKEN env var, e.g. "
+              "PVEAPIToken=root@pam!mcp-server=<secret>")
+        return False
+
     config = ProxmoxServerConfig(
         host="proxmox.mgmt.lakehouse.wtf",
         port=8006,


### PR DESCRIPTION
## Summary
A live, full-privilege, non-expiring `root@pam!mcp-server` Proxmox API token was committed in plaintext on public `main` (in `proxmox_mcp_config.json` and `test_token.py`).

**The token has already been rotated on Proxmox** — the previously-public value now returns HTTP 401 (verified). This PR stops the secret from being tracked going forward.

## Changes
- `git rm --cached proxmox_mcp_config.json` + add to `.gitignore` — the real config stays on disk (untracked) so the MCP server loads it normally; the new token is never committed.
- Add `proxmox_mcp_config.json.example` with a placeholder.
- `test_token.py`: read the token from the `PROXMOX_MCP_TOKEN` env var instead of hardcoding it.

## Note
Git history still contains the old token in earlier commits, but that value is **dead** (rotated), so it is neutralized. Optional follow-up: scrub history with git-filter-repo/BFG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)