### PR TITLE
feat(memory-search): local semantic-recall MCP server over memory + learnings

### DIFF
--- a/mcp-servers/memory-search-mcp-server/.gitignore
+++ b/mcp-servers/memory-search-mcp-server/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.egg-info/
+.pytest_cache/
+*.pyc

--- a/mcp-servers/memory-search-mcp-server/README.md
+++ b/mcp-servers/memory-search-mcp-server/README.md
@@ -1,0 +1,50 @@
+# memory-search-mcp-server
+
+Local semantic recall over Claude Code's persistent memory and learnings, as MCP
+tools. Embeddings run **locally** (ChromaDB's default MiniLM ONNX model), so both
+indexing and retrieval cost **zero API tokens**. Recall matches on *meaning*, not
+keywords, and indexes **every** memory file and learnings entry on disk — so it
+does not depend on `MEMORY.md`'s hand-curated index being complete or correct.
+
+## Why
+
+The auto-loaded `MEMORY.md` index has a size ceiling (it gets silently truncated
+when too large) and drifts (orphaned files, stale pointers). This server lets the
+bulk of reference/lookup memory live outside the always-loaded index while staying
+fully recallable on demand.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `memory_recall(query, k=8)` | Rank the most relevant memories + learnings for a natural-language query. |
+| `memory_read(name)` | Read the full text of a memory file or learnings file (`mistakes`/`anti-patterns`/…). |
+| `memory_reindex()` | Incrementally refresh the index (re-embeds only changed files). |
+| `memory_stats()` | Index size + indexed directories. |
+
+## Layout & config
+
+```
+src/memory_search_mcp/
+  core.py     indexing + search (single source of truth)
+  server.py   FastMCP server (memory-search-mcp entry point)
+  cli.py      CLI (memory-search entry point)
+```
+
+Paths are overridable via env vars (defaults are the dev box):
+`MEMORY_DIR`, `LEARNINGS_DIR`, `MEMSEARCH_DB`.
+
+## Install / run
+
+```sh
+python3 -m venv .venv && .venv/bin/pip install -e .
+.venv/bin/memory-search --reindex          # build the index (first run downloads MiniLM once)
+.venv/bin/memory-search "rotate a leaked secret"
+.venv/bin/pytest -q                         # smoke tests (isolated temp store)
+```
+
+Registered as an MCP server with:
+`claude mcp add -s user memory-search -- <venv>/bin/memory-search-mcp`
+
+A SessionStart hook (`~/.claude/hooks/memory-search-reindex.sh`) keeps the index
+fresh and reminds the agent that reference facts are recalled via `memory-search`.

--- a/mcp-servers/memory-search-mcp-server/pyproject.toml
+++ b/mcp-servers/memory-search-mcp-server/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/memory_search_mcp"]
+
+[project]
+name = "memory-search-mcp-server"
+version = "1.0.0"
+description = "MCP server for local semantic recall over Claude's memory + learnings (ChromaDB, zero API tokens)"
+requires-python = ">=3.11"
+dependencies = [
+    "mcp>=1.10.0",
+    "chromadb>=1.0.0",
+]
+
+[project.scripts]
+memory-search = "memory_search_mcp.cli:main"
+memory-search-mcp = "memory_search_mcp.server:main"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+]

--- a/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/__init__.py
+++ b/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Local semantic recall over Claude's memory + learnings (ChromaDB)."""

--- a/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/cli.py
+++ b/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/cli.py
@@ -1,0 +1,50 @@
+"""memory-search CLI — thin wrapper over memory_search_mcp.core.
+
+  memory-search "how do I rotate a leaked secret"   # recall (top-k)
+  memory-search --reindex                            # refresh the index
+  memory-search --stats                              # index size
+  memory-search "..." --k 10 --json                  # machine-readable
+"""
+import argparse
+import json
+
+from memory_search_mcp import core
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description="Local semantic recall over Claude memory + learnings")
+    ap.add_argument("query", nargs="?", default="")
+    ap.add_argument("--k", type=int, default=8)
+    ap.add_argument("--reindex", action="store_true")
+    ap.add_argument("--stats", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    a = ap.parse_args()
+
+    if a.reindex:
+        r = core.reindex()
+        print(f"reindex: +{r['changed']} changed, {r['unchanged']} unchanged, "
+              f"-{r['removed']} stale; total={r['total']}")
+        return
+    if a.stats:
+        s = core.stats()
+        print(f"collection '{s['collection']}': {s['count']} docs @ {s['db_dir']}")
+        return
+    if not a.query:
+        ap.error("provide a query, or --reindex / --stats")
+
+    rows = core.search(a.query, k=a.k)
+    if a.json:
+        print(json.dumps(rows, indent=2))
+        return
+    for r in rows:
+        print(f"[{r['score']:.3f}] {r['title']}  ({r['type']})")
+        print(f"        {r['file']}")
+        if r["desc"]:
+            print(f"        {r['desc']}")
+    if not rows:
+        print("(no results)")
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/core.py
+++ b/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/core.py
@@ -1,0 +1,169 @@
+"""Indexing + search core for the memory-search MCP server.
+
+Single source of truth shared by the CLI (`memory_search_mcp.cli`) and the MCP
+server (`memory_search_mcp.server`). Embeddings run locally via ChromaDB's
+default MiniLM ONNX model — no API tokens are spent on indexing or retrieval.
+
+Paths are overridable via env vars so the server can be pointed at any memory
+store (defaults match the dev box):
+  MEMORY_DIR     directory of *.md memory files (one fact per file)
+  LEARNINGS_DIR  directory of *.md learnings files (split per "### " entry)
+  MEMSEARCH_DB   ChromaDB persistence dir
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+
+MEMORY_DIR = os.environ.get(
+    "MEMORY_DIR",
+    "/home/dev/.claude/projects/-home-dev-workspace/memory",
+)
+LEARNINGS_DIR = os.environ.get("LEARNINGS_DIR", "/home/dev/.claude/learnings")
+DB_DIR = os.environ.get(
+    "MEMSEARCH_DB", os.path.expanduser("~/.cache/memory-search/chroma")
+)
+COLLECTION = "memory"
+
+# Files in MEMORY_DIR that are indexes/backups, not recallable content.
+_SKIP = {"MEMORY.md", "MEMORY-archive.md"}
+
+
+def _client():
+    import chromadb
+
+    os.makedirs(DB_DIR, exist_ok=True)
+    return chromadb.PersistentClient(path=DB_DIR)
+
+
+def _collection(client=None):
+    client = client or _client()
+    # Default embedding_function = ONNXMiniLM_L6_V2 (local, downloaded once).
+    return client.get_or_create_collection(COLLECTION)
+
+
+def _frontmatter(text: str) -> tuple[str, str, str]:
+    """Pull (name, description, type) from a memory file's YAML frontmatter."""
+    name = desc = mtype = ""
+    m = re.search(r"^name:\s*(.+)$", text, re.M)
+    if m:
+        name = m.group(1).strip().removeprefix("name:").strip()
+    m = re.search(r"^description:\s*(.+)$", text, re.M)
+    if m:
+        desc = m.group(1).strip().strip('"')
+    m = re.search(r"^\s*type:\s*(.+)$", text, re.M)
+    if m:
+        mtype = m.group(1).strip()
+    return name, desc, mtype
+
+
+def iter_docs():
+    """Yield (id, document, metadata) for every memory file + learnings entry."""
+    if os.path.isdir(MEMORY_DIR):
+        for path in sorted(glob.glob(os.path.join(MEMORY_DIR, "*.md"))):
+            fn = os.path.basename(path)
+            if fn in _SKIP or fn.endswith(".bak"):
+                continue
+            text = _read(path)
+            name, desc, mtype = _frontmatter(text)
+            title = name or fn[:-3]
+            doc = f"{title}\n{desc}\n{text}"[:8000]
+            yield fn, doc, {
+                "source": "memory", "file": fn, "path": path,
+                "title": title, "desc": desc[:300], "type": mtype or "memory",
+                "mtime": str(os.path.getmtime(path)),
+            }
+    if os.path.isdir(LEARNINGS_DIR):
+        for path in sorted(glob.glob(os.path.join(LEARNINGS_DIR, "*.md"))):
+            base = os.path.basename(path)[:-3]
+            text = _read(path)
+            mt = str(os.path.getmtime(path))
+            parts = re.split(r"(?m)^### ", text)
+            for i, part in enumerate(parts):
+                part = part.strip()
+                if i == 0 or not part:
+                    continue  # i==0 is the file preamble, not a recall entry
+                title = part.splitlines()[0].strip("# ").strip()
+                doc = ("### " + part)[:8000]
+                yield f"learn:{base}#{i}", doc, {
+                    "source": "learnings", "file": base, "path": path,
+                    "title": title[:120], "desc": title[:300],
+                    "type": f"learning/{base}", "mtime": mt,
+                }
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def reindex() -> dict:
+    """Incrementally refresh the index; returns counts. Re-embeds only files
+    whose mtime changed, and drops ids whose source file/entry is gone."""
+    coll = _collection()
+    existing = {}
+    got = coll.get(include=["metadatas"])
+    for _id, md in zip(got["ids"], got["metadatas"]):
+        existing[_id] = (md or {}).get("mtime")
+    ids, docs, metas, seen = [], [], [], set()
+    changed = unchanged = 0
+    for _id, doc, md in iter_docs():
+        seen.add(_id)
+        if existing.get(_id) == md["mtime"]:
+            unchanged += 1
+            continue
+        ids.append(_id); docs.append(doc); metas.append(md); changed += 1
+    stale = [i for i in existing if i not in seen]
+    if stale:
+        coll.delete(ids=stale)
+    for j in range(0, len(ids), 100):
+        coll.upsert(ids=ids[j:j + 100], documents=docs[j:j + 100],
+                    metadatas=metas[j:j + 100])
+    return {"changed": changed, "unchanged": unchanged,
+            "removed": len(stale), "total": coll.count()}
+
+
+def search(query: str, k: int = 8) -> list[dict]:
+    """Return up to k semantically-relevant entries, most-relevant first.
+    Auto-indexes on first use if the collection is empty."""
+    coll = _collection()
+    if coll.count() == 0:
+        reindex()
+        coll = _collection()
+    res = coll.query(query_texts=[query], n_results=max(1, k),
+                     include=["metadatas", "distances"])
+    rows = []
+    for md, dist in zip(res["metadatas"][0], res["distances"][0]):
+        rows.append({
+            "score": round(1 - dist / 2, 3),  # cosine distance -> ~0..1 similarity
+            "title": md.get("title", ""),
+            "type": md.get("type", ""),
+            "file": md.get("file", ""),
+            "path": md.get("path", ""),
+            "desc": md.get("desc", ""),
+        })
+    return rows
+
+
+def read_entry(name: str) -> dict:
+    """Return the full text of a memory file (e.g. 'reference_pushover_credentials.md'
+    or without the .md) or a learnings file ('mistakes'/'anti-patterns'/...)."""
+    candidates = []
+    if name.endswith(".md"):
+        candidates.append(os.path.join(MEMORY_DIR, name))
+    else:
+        candidates.append(os.path.join(MEMORY_DIR, name + ".md"))
+        candidates.append(os.path.join(LEARNINGS_DIR, name + ".md"))
+        candidates.append(os.path.join(LEARNINGS_DIR, name.replace("learning/", "") + ".md"))
+    for path in candidates:
+        if os.path.isfile(path):
+            return {"name": name, "path": path, "content": _read(path)}
+    return {"name": name, "path": None, "content": None,
+            "error": f"not found in {MEMORY_DIR} or {LEARNINGS_DIR}"}
+
+
+def stats() -> dict:
+    return {"collection": COLLECTION, "count": _collection().count(),
+            "db_dir": DB_DIR, "memory_dir": MEMORY_DIR,
+            "learnings_dir": LEARNINGS_DIR}

--- a/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/server.py
+++ b/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/server.py
@@ -1,0 +1,85 @@
+# src/memory_search_mcp/server.py
+"""Memory Search MCP Server — local semantic recall for Claude Code.
+
+Exposes Claude's own memory store (per-fact memory files) and the learnings
+knowledge base as searchable tools. Embeddings run locally (ChromaDB MiniLM),
+so recall costs zero API tokens and does not depend on MEMORY.md's hand-curated
+index being complete or correct.
+"""
+import logging
+import sys
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from memory_search_mcp import core
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stderr)],
+)
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("Memory Search")
+
+
+@mcp.tool()
+def memory_recall(query: str, k: int = 8) -> dict[str, Any]:
+    """Semantically recall the most relevant memories + learnings for a query.
+
+    Use this whenever the loaded MEMORY.md index doesn't already answer a recall
+    need — especially for reference/lookup facts (IPs, credential locations, API
+    quirks, infra details) and past mistakes/learnings. Matches on meaning, not
+    keywords, so natural-language questions work ("how do I rotate a leaked
+    secret", "why did my commit land on the wrong branch").
+
+    Returns ranked hits with `score` (≈0..1 similarity), `title`, `type`
+    (memory type or learning/<file>), `file`, and a short `desc`. Call
+    `memory_read` with a hit's `file` to pull its full text.
+
+    Args:
+        query: Natural-language description of what you're trying to recall.
+        k: Max number of hits to return (default 8).
+    """
+    rows = core.search(query, k=k)
+    return {"query": query, "count": len(rows), "results": rows}
+
+
+@mcp.tool()
+def memory_read(name: str) -> dict[str, Any]:
+    """Read the full text of a single memory or learnings file.
+
+    Use after `memory_recall` to expand a promising hit. Accepts a memory
+    filename ("reference_pushover_credentials.md" or without ".md") or a
+    learnings file base name ("mistakes", "anti-patterns", "environment",
+    "validated").
+
+    Args:
+        name: Memory filename or learnings base name from a recall hit's `file`.
+    """
+    return core.read_entry(name)
+
+
+@mcp.tool()
+def memory_reindex() -> dict[str, Any]:
+    """Refresh the semantic index (incremental — re-embeds only changed files,
+    drops removed ones). Runs automatically at session start; call this after
+    writing new memories/learnings within a session to make them recallable now.
+    """
+    return core.reindex()
+
+
+@mcp.tool()
+def memory_stats() -> dict[str, Any]:
+    """Report index size and the directories being indexed."""
+    return core.stats()
+
+
+def main() -> None:
+    logger.info("Starting Memory Search MCP server (%s)", core.stats())
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-servers/memory-search-mcp-server/tests/test_core.py
+++ b/mcp-servers/memory-search-mcp-server/tests/test_core.py
@@ -1,0 +1,53 @@
+"""Smoke tests for the indexing/search core against a temp memory store."""
+import importlib
+
+
+def _fresh_core(tmp_path, monkeypatch):
+    mem = tmp_path / "memory"
+    learn = tmp_path / "learnings"
+    mem.mkdir()
+    learn.mkdir()
+    (mem / "reference_widget_api.md").write_text(
+        "---\nname: Widget API access\n"
+        "description: The widget service lives at 10.0.0.5 port 9000, token in vault\n"
+        "metadata:\n  type: reference\n---\n\nBearer token rotates monthly.\n",
+        encoding="utf-8",
+    )
+    (mem / "MEMORY.md").write_text("# index — should be skipped\n", encoding="utf-8")
+    (learn / "mistakes.md").write_text(
+        "# Mistakes\n\n"
+        "### Never delete the prod database without a snapshot — 2026-01-01\n"
+        "- Wrong: dropped the table. Right: snapshot first.\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MEMORY_DIR", str(mem))
+    monkeypatch.setenv("LEARNINGS_DIR", str(learn))
+    monkeypatch.setenv("MEMSEARCH_DB", str(tmp_path / "chroma"))
+    import memory_search_mcp.core as core
+    return importlib.reload(core)
+
+
+def test_reindex_counts_memory_and_learnings(tmp_path, monkeypatch):
+    core = _fresh_core(tmp_path, monkeypatch)
+    r = core.reindex()
+    # 1 memory file (MEMORY.md skipped) + 1 learnings entry
+    assert r["total"] == 2
+    assert r["changed"] == 2
+    # Second pass: nothing changed.
+    assert core.reindex()["changed"] == 0
+
+
+def test_search_finds_by_meaning_not_keyword(tmp_path, monkeypatch):
+    core = _fresh_core(tmp_path, monkeypatch)
+    core.reindex()
+    rows = core.search("where does the gadget server run", k=3)
+    assert rows and rows[0]["file"] == "reference_widget_api.md"
+    rows = core.search("avoid wiping the database", k=3)
+    assert any("Never delete the prod database" in r["title"] for r in rows)
+
+
+def test_read_entry(tmp_path, monkeypatch):
+    core = _fresh_core(tmp_path, monkeypatch)
+    out = core.read_entry("reference_widget_api.md")
+    assert "10.0.0.5" in out["content"]
+    assert core.read_entry("nope_missing")["content"] is None


### PR DESCRIPTION
## What

Adds **`memory-search-mcp-server`** — ChromaDB-backed semantic recall over Claude Code's persistent memory files and the learnings knowledge base, exposed as MCP tools. Embeddings run **locally** (default MiniLM ONNX), so indexing and retrieval cost **zero API tokens**, and recall indexes *every* file on disk rather than depending on `MEMORY.md`'s hand-curated index being complete/correct.

## Why

The auto-loaded `MEMORY.md` index has a size ceiling (silently truncated when too large) and drifts over time (orphaned files, stale/corrupted pointers). This server lets reference/lookup memory live outside the always-loaded index while staying fully recallable on demand — matching on meaning, not keywords.

## Tools

| Tool | Purpose |
|---|---|
| `memory_recall(query, k=8)` | Rank the most relevant memories + learnings for a natural-language query |
| `memory_read(name)` | Read the full text of a memory file or learnings file |
| `memory_reindex()` | Incremental refresh (re-embeds only changed files) |
| `memory_stats()` | Index size + indexed dirs |

## Design

- Follows the repo's Python FastMCP convention (mirrors `gmail-manage-mcp-server`).
- `core.py` is the single source of truth shared by the FastMCP server and the `memory-search` CLI.
- Paths overridable via `MEMORY_DIR` / `LEARNINGS_DIR` / `MEMSEARCH_DB`.

## Testing

- `pytest -q` → 3/3 pass (indexing counts, meaning-based search, read) against an isolated temp store.
- Registered with `claude mcp add` → **✔ Connected**; end-to-end stdio tool call verified (`memory_recall` returns correct hits; 346 docs indexed on the live store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)