### PR TITLE
feat(memory-search): index per-project .claude/learnings across the monorepo

### DIFF
--- a/mcp-servers/memory-search-mcp-server/README.md
+++ b/mcp-servers/memory-search-mcp-server/README.md
@@ -6,21 +6,28 @@ indexing and retrieval cost **zero API tokens**. Recall matches on *meaning*, no
 keywords, and indexes **every** memory file and learnings entry on disk — so it
 does not depend on `MEMORY.md`'s hand-curated index being complete or correct.
 
+Coverage spans the whole monorepo: the **global** workspace memory + global
+learnings, **and** each project's own `.claude/learnings` (e.g. `operations`,
+`stormcrow`, `home-assistant-config`). Every hit is tagged with its `project`
+(`(global)` or the repo name); `memory_recall(..., project="operations")` scopes
+to that repo's learnings plus global.
+
 ## Why
 
 The auto-loaded `MEMORY.md` index has a size ceiling (it gets silently truncated
 when too large) and drifts (orphaned files, stale pointers). This server lets the
 bulk of reference/lookup memory live outside the always-loaded index while staying
-fully recallable on demand.
+fully recallable on demand — and surfaces per-project learnings that were never in
+`MEMORY.md` at all.
 
 ## Tools
 
 | Tool | Purpose |
 |---|---|
-| `memory_recall(query, k=8)` | Rank the most relevant memories + learnings for a natural-language query. |
-| `memory_read(name)` | Read the full text of a memory file or learnings file (`mistakes`/`anti-patterns`/…). |
+| `memory_recall(query, k=8, project=None)` | Rank the most relevant memories + learnings for a query; optional `project` scopes to that repo + global. |
+| `memory_read(name)` | Read the full text of a hit — pass a recall hit's `path` (works for per-project learnings) or a global memory/learnings name. |
 | `memory_reindex()` | Incrementally refresh the index (re-embeds only changed files). |
-| `memory_stats()` | Index size + indexed directories. |
+| `memory_stats()` | Index size + per-project doc breakdown. |
 
 ## Layout & config
 
@@ -32,7 +39,8 @@ src/memory_search_mcp/
 ```
 
 Paths are overridable via env vars (defaults are the dev box):
-`MEMORY_DIR`, `LEARNINGS_DIR`, `MEMSEARCH_DB`.
+`MEMORY_DIR`, `LEARNINGS_DIR`, `WORKSPACE_DIR` (monorepo root, walked for
+per-project `.claude/learnings`), `MEMSEARCH_DB`.
 
 ## Install / run
 

--- a/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/cli.py
+++ b/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/cli.py
@@ -16,6 +16,8 @@ def main() -> None:
         description="Local semantic recall over Claude memory + learnings")
     ap.add_argument("query", nargs="?", default="")
     ap.add_argument("--k", type=int, default=8)
+    ap.add_argument("--project", default=None,
+                    help="scope to a repo's learnings (e.g. operations) + global")
     ap.add_argument("--reindex", action="store_true")
     ap.add_argument("--stats", action="store_true")
     ap.add_argument("--json", action="store_true")
@@ -29,17 +31,19 @@ def main() -> None:
     if a.stats:
         s = core.stats()
         print(f"collection '{s['collection']}': {s['count']} docs @ {s['db_dir']}")
+        for proj, n in s.get("projects", {}).items():
+            print(f"  {n:5d}  {proj}")
         return
     if not a.query:
         ap.error("provide a query, or --reindex / --stats")
 
-    rows = core.search(a.query, k=a.k)
+    rows = core.search(a.query, k=a.k, project=a.project)
     if a.json:
         print(json.dumps(rows, indent=2))
         return
     for r in rows:
         print(f"[{r['score']:.3f}] {r['title']}  ({r['type']})")
-        print(f"        {r['file']}")
+        print(f"        {r['project']} :: {r['file']}")
         if r["desc"]:
             print(f"        {r['desc']}")
     if not rows:

--- a/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/core.py
+++ b/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/core.py
@@ -7,8 +7,14 @@ default MiniLM ONNX model — no API tokens are spent on indexing or retrieval.
 Paths are overridable via env vars so the server can be pointed at any memory
 store (defaults match the dev box):
   MEMORY_DIR     directory of *.md memory files (one fact per file)
-  LEARNINGS_DIR  directory of *.md learnings files (split per "### " entry)
+  LEARNINGS_DIR  directory of *.md global learnings files (split per "### " entry)
+  WORKSPACE_DIR  monorepo root; per-project .claude/learnings are also indexed
   MEMSEARCH_DB   ChromaDB persistence dir
+
+Every doc carries a `project` metadata key: "(global)" for the workspace memory
+store + global learnings, or the project path (e.g. "operations", "stormcrow")
+for per-project .claude/learnings. search(..., project=X) returns X's entries
+plus global ones.
 """
 from __future__ import annotations
 
@@ -21,13 +27,18 @@ MEMORY_DIR = os.environ.get(
     "/home/dev/.claude/projects/-home-dev-workspace/memory",
 )
 LEARNINGS_DIR = os.environ.get("LEARNINGS_DIR", "/home/dev/.claude/learnings")
+WORKSPACE_DIR = os.environ.get("WORKSPACE_DIR", "/home/dev/workspace")
 DB_DIR = os.environ.get(
     "MEMSEARCH_DB", os.path.expanduser("~/.cache/memory-search/chroma")
 )
 COLLECTION = "memory"
+GLOBAL = "(global)"
 
 # Files in MEMORY_DIR that are indexes/backups, not recallable content.
 _SKIP = {"MEMORY.md", "MEMORY-archive.md"}
+# Dirs never descended into when walking WORKSPACE_DIR for project learnings.
+_PRUNE = {"node_modules", ".git", ".worktrees", ".venv", "venv", "__pycache__",
+          "dist", "build", ".next", "coverage", ".cache", "target", ".pytest_cache"}
 
 
 def _client():
@@ -72,25 +83,58 @@ def iter_docs():
             yield fn, doc, {
                 "source": "memory", "file": fn, "path": path,
                 "title": title, "desc": desc[:300], "type": mtype or "memory",
-                "mtime": str(os.path.getmtime(path)),
+                "project": GLOBAL, "mtime": str(os.path.getmtime(path)),
             }
+    # Global learnings KB.
     if os.path.isdir(LEARNINGS_DIR):
         for path in sorted(glob.glob(os.path.join(LEARNINGS_DIR, "*.md"))):
             base = os.path.basename(path)[:-3]
-            text = _read(path)
-            mt = str(os.path.getmtime(path))
-            parts = re.split(r"(?m)^### ", text)
-            for i, part in enumerate(parts):
-                part = part.strip()
-                if i == 0 or not part:
-                    continue  # i==0 is the file preamble, not a recall entry
-                title = part.splitlines()[0].strip("# ").strip()
-                doc = ("### " + part)[:8000]
-                yield f"learn:{base}#{i}", doc, {
-                    "source": "learnings", "file": base, "path": path,
-                    "title": title[:120], "desc": title[:300],
-                    "type": f"learning/{base}", "mtime": mt,
-                }
+            yield from _emit_learning_entries(path, base, GLOBAL, f"learn:{base}")
+    # Per-project .claude/learnings across the monorepo.
+    yield from _iter_project_learnings()
+
+
+def _emit_learning_entries(path, base, project, id_prefix):
+    """Split a learnings file into per-'### ' entries and yield index docs."""
+    text = _read(path)
+    mt = str(os.path.getmtime(path))
+    type_label = f"learning/{base}" if project == GLOBAL else f"{project}/learning/{base}"
+    parts = re.split(r"(?m)^### ", text)
+    for i, part in enumerate(parts):
+        part = part.strip()
+        if i == 0 or not part:
+            continue  # i==0 is the file preamble, not a recall entry
+        title = part.splitlines()[0].strip("# ").strip()
+        doc = ("### " + part)[:8000]
+        yield f"{id_prefix}#{i}", doc, {
+            "source": "learnings", "file": base, "path": path,
+            "title": title[:120], "desc": title[:300],
+            "type": type_label, "project": project, "mtime": mt,
+        }
+
+
+def _iter_project_learnings():
+    """Walk WORKSPACE_DIR for per-project .claude/learnings (file or dir),
+    tagging each entry with its source project (relpath of the .claude parent)."""
+    if not os.path.isdir(WORKSPACE_DIR):
+        return
+    for root, dirs, _files in os.walk(WORKSPACE_DIR):
+        dirs[:] = [d for d in dirs if d not in _PRUNE]
+        if os.path.basename(root) != ".claude":
+            continue
+        project = os.path.relpath(os.path.dirname(root), WORKSPACE_DIR)
+        # Single-file form: <proj>/.claude/learnings.md
+        lm = os.path.join(root, "learnings.md")
+        if os.path.isfile(lm):
+            yield from _emit_learning_entries(lm, "learnings", project,
+                                              f"proj:{project}:learnings")
+        # Split form: <proj>/.claude/learnings/*.md
+        ldir = os.path.join(root, "learnings")
+        if os.path.isdir(ldir):
+            for path in sorted(glob.glob(os.path.join(ldir, "*.md"))):
+                base = os.path.basename(path)[:-3]
+                yield from _emit_learning_entries(path, base, project,
+                                                  f"proj:{project}:{base}")
 
 
 def _read(path: str) -> str:
@@ -124,14 +168,16 @@ def reindex() -> dict:
             "removed": len(stale), "total": coll.count()}
 
 
-def search(query: str, k: int = 8) -> list[dict]:
+def search(query: str, k: int = 8, project: str | None = None) -> list[dict]:
     """Return up to k semantically-relevant entries, most-relevant first.
-    Auto-indexes on first use if the collection is empty."""
+    Auto-indexes on first use if the collection is empty. If `project` is given,
+    restrict to that project's entries plus the global store."""
     coll = _collection()
     if coll.count() == 0:
         reindex()
         coll = _collection()
-    res = coll.query(query_texts=[query], n_results=max(1, k),
+    where = {"project": {"$in": [project, GLOBAL]}} if project else None
+    res = coll.query(query_texts=[query], n_results=max(1, k), where=where,
                      include=["metadatas", "distances"])
     rows = []
     for md, dist in zip(res["metadatas"][0], res["distances"][0]):
@@ -139,6 +185,7 @@ def search(query: str, k: int = 8) -> list[dict]:
             "score": round(1 - dist / 2, 3),  # cosine distance -> ~0..1 similarity
             "title": md.get("title", ""),
             "type": md.get("type", ""),
+            "project": md.get("project", ""),
             "file": md.get("file", ""),
             "path": md.get("path", ""),
             "desc": md.get("desc", ""),
@@ -147,10 +194,14 @@ def search(query: str, k: int = 8) -> list[dict]:
 
 
 def read_entry(name: str) -> dict:
-    """Return the full text of a memory file (e.g. 'reference_pushover_credentials.md'
-    or without the .md) or a learnings file ('mistakes'/'anti-patterns'/...)."""
+    """Return the full text of a recall hit. Accepts an absolute path (from a
+    hit's `path` — works for per-project learnings), a memory filename
+    ('reference_x.md' or without .md), or a global learnings base name
+    ('mistakes'/'anti-patterns'/...)."""
     candidates = []
-    if name.endswith(".md"):
+    if os.path.isabs(name):
+        candidates.append(name)
+    elif name.endswith(".md"):
         candidates.append(os.path.join(MEMORY_DIR, name))
     else:
         candidates.append(os.path.join(MEMORY_DIR, name + ".md"))
@@ -160,10 +211,17 @@ def read_entry(name: str) -> dict:
         if os.path.isfile(path):
             return {"name": name, "path": path, "content": _read(path)}
     return {"name": name, "path": None, "content": None,
-            "error": f"not found in {MEMORY_DIR} or {LEARNINGS_DIR}"}
+            "error": f"not found (tried absolute path, {MEMORY_DIR}, {LEARNINGS_DIR}); "
+                     f"pass a recall hit's full `path` for per-project learnings"}
 
 
 def stats() -> dict:
-    return {"collection": COLLECTION, "count": _collection().count(),
+    coll = _collection()
+    got = coll.get(include=["metadatas"])
+    by_project: dict[str, int] = {}
+    for md in got["metadatas"]:
+        by_project[(md or {}).get("project", "?")] = by_project.get((md or {}).get("project", "?"), 0) + 1
+    return {"collection": COLLECTION, "count": coll.count(),
             "db_dir": DB_DIR, "memory_dir": MEMORY_DIR,
-            "learnings_dir": LEARNINGS_DIR}
+            "learnings_dir": LEARNINGS_DIR, "workspace_dir": WORKSPACE_DIR,
+            "projects": dict(sorted(by_project.items(), key=lambda x: -x[1]))}

--- a/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/server.py
+++ b/mcp-servers/memory-search-mcp-server/src/memory_search_mcp/server.py
@@ -25,7 +25,7 @@ mcp = FastMCP("Memory Search")
 
 
 @mcp.tool()
-def memory_recall(query: str, k: int = 8) -> dict[str, Any]:
+def memory_recall(query: str, k: int = 8, project: str | None = None) -> dict[str, Any]:
     """Semantically recall the most relevant memories + learnings for a query.
 
     Use this whenever the loaded MEMORY.md index doesn't already answer a recall
@@ -34,15 +34,21 @@ def memory_recall(query: str, k: int = 8) -> dict[str, Any]:
     keywords, so natural-language questions work ("how do I rotate a leaked
     secret", "why did my commit land on the wrong branch").
 
-    Returns ranked hits with `score` (≈0..1 similarity), `title`, `type`
-    (memory type or learning/<file>), `file`, and a short `desc`. Call
-    `memory_read` with a hit's `file` to pull its full text.
+    Indexes the global workspace memory + global learnings AND every project's
+    own .claude/learnings across the monorepo. Each hit carries `project`
+    ("(global)" or a repo name like "operations"/"stormcrow").
+
+    Returns ranked hits with `score` (≈0..1 similarity), `title`, `type`,
+    `project`, `file`, and a short `desc`. Call `memory_read` with a hit's
+    `path` (or `file` for global entries) to pull its full text.
 
     Args:
         query: Natural-language description of what you're trying to recall.
         k: Max number of hits to return (default 8).
+        project: Optional repo name to scope to (e.g. "operations"); returns
+            that project's learnings plus the global store.
     """
-    rows = core.search(query, k=k)
+    rows = core.search(query, k=k, project=project)
     return {"query": query, "count": len(rows), "results": rows}
 
 

--- a/mcp-servers/memory-search-mcp-server/tests/test_core.py
+++ b/mcp-servers/memory-search-mcp-server/tests/test_core.py
@@ -5,6 +5,7 @@ import importlib
 def _fresh_core(tmp_path, monkeypatch):
     mem = tmp_path / "memory"
     learn = tmp_path / "learnings"
+    ws = tmp_path / "workspace"
     mem.mkdir()
     learn.mkdir()
     (mem / "reference_widget_api.md").write_text(
@@ -20,21 +21,35 @@ def _fresh_core(tmp_path, monkeypatch):
         "- Wrong: dropped the table. Right: snapshot first.\n",
         encoding="utf-8",
     )
+    # A per-project learnings file in the workspace (single-file form), plus a
+    # pruned node_modules copy that MUST be ignored.
+    proj = ws / "acme-svc" / ".claude"
+    proj.mkdir(parents=True)
+    (proj / "learnings.md").write_text(
+        "# acme-svc learnings\n\n"
+        "### The acme widget queue drops messages over 256KB — chunk them — 2026-02-02\n"
+        "- Wrong: sent a 1MB blob. Right: split into 200KB chunks.\n",
+        encoding="utf-8",
+    )
+    nm = ws / "acme-svc" / "node_modules" / "pkg" / ".claude"
+    nm.mkdir(parents=True)
+    (nm / "learnings.md").write_text("### should be pruned — 2026-01-01\n- x\n", encoding="utf-8")
     monkeypatch.setenv("MEMORY_DIR", str(mem))
     monkeypatch.setenv("LEARNINGS_DIR", str(learn))
+    monkeypatch.setenv("WORKSPACE_DIR", str(ws))
     monkeypatch.setenv("MEMSEARCH_DB", str(tmp_path / "chroma"))
     import memory_search_mcp.core as core
     return importlib.reload(core)
 
 
-def test_reindex_counts_memory_and_learnings(tmp_path, monkeypatch):
+def test_reindex_counts_memory_learnings_and_projects(tmp_path, monkeypatch):
     core = _fresh_core(tmp_path, monkeypatch)
     r = core.reindex()
-    # 1 memory file (MEMORY.md skipped) + 1 learnings entry
-    assert r["total"] == 2
-    assert r["changed"] == 2
-    # Second pass: nothing changed.
-    assert core.reindex()["changed"] == 0
+    # 1 memory file (MEMORY.md skipped) + 1 global learning + 1 project learning
+    # (node_modules copy pruned).
+    assert r["total"] == 3
+    assert r["changed"] == 3
+    assert core.reindex()["changed"] == 0  # second pass: nothing changed
 
 
 def test_search_finds_by_meaning_not_keyword(tmp_path, monkeypatch):
@@ -46,8 +61,26 @@ def test_search_finds_by_meaning_not_keyword(tmp_path, monkeypatch):
     assert any("Never delete the prod database" in r["title"] for r in rows)
 
 
+def test_project_learnings_indexed_and_filterable(tmp_path, monkeypatch):
+    core = _fresh_core(tmp_path, monkeypatch)
+    core.reindex()
+    # The project learning is recallable and tagged with its project.
+    rows = core.search("large payload size limit on the queue", k=5)
+    hit = next((r for r in rows if "acme widget queue" in r["title"]), None)
+    assert hit is not None and hit["project"] == "acme-svc"
+    # node_modules copy was pruned.
+    assert core.stats()["projects"].get("acme-svc") == 1
+    # project filter returns project + global, never the wrong project.
+    rows = core.search("database", k=5, project="acme-svc")
+    assert all(r["project"] in ("acme-svc", "(global)") for r in rows)
+
+
 def test_read_entry(tmp_path, monkeypatch):
     core = _fresh_core(tmp_path, monkeypatch)
+    core.reindex()
     out = core.read_entry("reference_widget_api.md")
     assert "10.0.0.5" in out["content"]
+    # per-project learning is read via its absolute path (from a recall hit)
+    hit = core.search("acme widget queue 256KB", k=5)[0]
+    assert "256KB" in core.read_entry(hit["path"])["content"]
     assert core.read_entry("nope_missing")["content"] is None


### PR DESCRIPTION
## What

Extends `memory-search` (the local semantic-recall MCP server from #47) to index **every project's own `.claude/learnings`** across the monorepo — not just the global workspace memory + global learnings.

Before: 347 docs, global-only. After: **675 docs across 15 projects** (`operations`, `home-assistant-config`, `homelab-iac`, `stormcrow`, `proxmox-agent`, `heydj`, …).

## How

- `core.iter_docs()` walks `WORKSPACE_DIR` for each project's `.claude/learnings.md` (single-file) or `.claude/learnings/*.md` (split), pruning `node_modules`/`.git`/`.worktrees`/build dirs.
- Every doc is tagged with a `project` metadata key (`(global)` or the repo relpath).
- `search(..., project=X)` / `memory_recall(..., project=X)` scope to that repo's learnings **plus** global (`$in` filter).
- `memory_read` accepts an absolute path, so per-project learnings open from a hit's `path`.
- `memory_stats` reports a per-project doc breakdown.

## Reachability vs coverage

The server was already user-scoped (reachable in all repos); this PR makes its **content** cover the whole monorepo, closing the gap where per-project learnings were invisible to recall.

## Testing

- `pytest -q` → 4/4 pass: project indexing, `node_modules` pruning, project-scoped search (never returns the wrong project), and absolute-path read.
- Live rebuild verified: 675 docs, 15 projects, no untagged docs; cross-project and `--project`-scoped recall confirmed (e.g. an `operations` syslog-parser learning surfaces tagged `operations :: validated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)