### PR TITLE
fix(dashboard): green the jest suite — 18 failing tests + 2 hook/component bugs (#1787)

### DIFF
--- a/dashboard/src/__tests__/components/ConnectionStatus.test.tsx
+++ b/dashboard/src/__tests__/components/ConnectionStatus.test.tsx
@@ -19,8 +19,10 @@ describe('ConnectionStatus', () => {
   it('should render connected status correctly', () => {
     render(<ConnectionStatus {...defaultProps} />);
 
-    expect(screen.getByText('Connected')).toBeInTheDocument();
-    expect(screen.getByText('50ms')).toBeInTheDocument();
+    // The status label and latency are rendered in both the inline status area
+    // and the (always-mounted) hover tooltip, so they appear more than once.
+    expect(screen.getAllByText('Connected').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('50ms').length).toBeGreaterThan(0);
     expect(screen.getByText('3 clients')).toBeInTheDocument();
     expect(screen.getByText('1h uptime')).toBeInTheDocument();
   });
@@ -34,7 +36,7 @@ describe('ConnectionStatus', () => {
       />
     );
 
-    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+    expect(screen.getAllByText('Connecting...').length).toBeGreaterThan(0);
 
     // Should have animated pulse effect
     const statusDot = document.querySelector('.animate-pulse');
@@ -51,7 +53,7 @@ describe('ConnectionStatus', () => {
       />
     );
 
-    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+    expect(screen.getAllByText('Disconnected').length).toBeGreaterThan(0);
 
     const retryButton = screen.getByText('Retry');
     expect(retryButton).toBeInTheDocument();
@@ -70,7 +72,7 @@ describe('ConnectionStatus', () => {
       />
     );
 
-    expect(screen.getByText('Connection Error')).toBeInTheDocument();
+    expect(screen.getAllByText('Connection Error').length).toBeGreaterThan(0);
 
     const retryButton = screen.getByText('Retry');
     expect(retryButton).toBeInTheDocument();
@@ -96,35 +98,39 @@ describe('ConnectionStatus', () => {
   });
 
   it('should format last update time correctly', () => {
-    const now = new Date('2025-01-01T12:00:00Z');
-    jest.spyOn(Date, 'now').mockImplementation(() => now.getTime());
+    // The component reads `new Date()` (not Date.now()), so freeze the system
+    // clock with fake timers rather than spying on Date.now.
+    jest.useFakeTimers().setSystemTime(new Date('2025-01-01T12:00:00Z'));
 
-    const { rerender } = render(
-      <ConnectionStatus
-        {...defaultProps}
-        lastUpdate="2025-01-01T11:59:30Z"
-      />
-    );
-    expect(screen.getByText('Updated 30s ago')).toBeInTheDocument();
+    try {
+      const { rerender } = render(
+        <ConnectionStatus
+          {...defaultProps}
+          lastUpdate="2025-01-01T11:59:30Z"
+        />
+      );
+      expect(screen.getByText('Updated 30s ago')).toBeInTheDocument();
 
-    rerender(
-      <ConnectionStatus
-        {...defaultProps}
-        lastUpdate="2025-01-01T11:58:00Z"
-      />
-    );
-    expect(screen.getByText('Updated 2m ago')).toBeInTheDocument();
+      rerender(
+        <ConnectionStatus
+          {...defaultProps}
+          lastUpdate="2025-01-01T11:58:00Z"
+        />
+      );
+      expect(screen.getByText('Updated 2m ago')).toBeInTheDocument();
 
-    rerender(
-      <ConnectionStatus
-        {...defaultProps}
-        lastUpdate="2025-01-01T10:00:00Z"
-      />
-    );
-    // Should show actual time for older updates
-    expect(screen.getByText(/10:00:00/)).toBeInTheDocument();
-
-    jest.restoreAllMocks();
+      rerender(
+        <ConnectionStatus
+          {...defaultProps}
+          lastUpdate="2025-01-01T10:00:00Z"
+        />
+      );
+      // Older updates fall back to an absolute clock time (toLocaleTimeString).
+      // The exact string is timezone-dependent, so just assert a HH:MM:SS shape.
+      expect(screen.getByText(/Updated \d{1,2}:\d{2}:\d{2}/)).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('should show tooltip with detailed information on hover', async () => {
@@ -135,28 +141,33 @@ describe('ConnectionStatus', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Status:')).toBeInTheDocument();
-      expect(screen.getByText('Connected')).toBeInTheDocument();
+      expect(screen.getAllByText('Connected').length).toBeGreaterThan(0);
       expect(screen.getByText('Latency:')).toBeInTheDocument();
-      expect(screen.getByText('50ms')).toBeInTheDocument();
+      expect(screen.getAllByText('50ms').length).toBeGreaterThan(0);
       expect(screen.getByText('Quality:')).toBeInTheDocument();
-      expect(screen.getByText('Excellent')).toBeInTheDocument();
+      // Rendered lowercase; "Excellent" is purely a CSS `capitalize` effect.
+      expect(screen.getByText('excellent')).toBeInTheDocument();
     });
   });
 
   it('should display connection quality colors correctly', () => {
+    // "50ms" appears in both the inline badge (carries the quality color) and
+    // the tooltip (plain). The inline badge is the first match in DOM order.
+    const inlineLatency = () => screen.getAllByText('50ms')[0];
+
     const { rerender } = render(
       <ConnectionStatus {...defaultProps} connectionQuality="excellent" />
     );
-    expect(screen.getByText('50ms')).toHaveClass('text-green-600');
+    expect(inlineLatency()).toHaveClass('text-green-600');
 
     rerender(<ConnectionStatus {...defaultProps} connectionQuality="good" />);
-    expect(screen.getByText('50ms')).toHaveClass('text-yellow-600');
+    expect(inlineLatency()).toHaveClass('text-yellow-600');
 
     rerender(<ConnectionStatus {...defaultProps} connectionQuality="poor" />);
-    expect(screen.getByText('50ms')).toHaveClass('text-red-600');
+    expect(inlineLatency()).toHaveClass('text-red-600');
 
     rerender(<ConnectionStatus {...defaultProps} connectionQuality="unknown" />);
-    expect(screen.getByText('50ms')).toHaveClass('text-gray-600');
+    expect(inlineLatency()).toHaveClass('text-gray-600');
   });
 
   it('should handle missing optional props gracefully', () => {
@@ -167,11 +178,13 @@ describe('ConnectionStatus', () => {
       />
     );
 
-    expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.getAllByText('Connected').length).toBeGreaterThan(0);
 
-    // Should not crash with missing optional props
+    // Should not crash with missing optional props. Latency 0ms still shows in
+    // the tooltip, but the inline "N clients" is hidden when clientCount is 0
+    // (the component guards it behind clientCount > 0).
     expect(screen.queryByText('0ms')).toBeInTheDocument();
-    expect(screen.queryByText('0 clients')).toBeInTheDocument();
+    expect(screen.queryByText('0 clients')).not.toBeInTheDocument();
   });
 
   it('should handle invalid lastUpdate gracefully', () => {
@@ -216,7 +229,10 @@ describe('ConnectionStatus', () => {
       />
     );
 
-    expect(screen.getByText('Updated Never')).toBeInTheDocument();
+    // With an empty timestamp the component omits the "Updated …" line entirely
+    // (both inline and tooltip are guarded by `lastUpdate &&`), rather than
+    // rendering a stray "Updated ". Graceful handling = the line is absent.
+    expect(screen.queryByText(/^Updated/)).not.toBeInTheDocument();
   });
 
   it('should show appropriate tooltips for disconnected state', async () => {

--- a/dashboard/src/__tests__/hooks/useAuditData.test.tsx
+++ b/dashboard/src/__tests__/hooks/useAuditData.test.tsx
@@ -230,9 +230,11 @@ describe('useAuditData', () => {
       expect(result.current.isRealTime).toBe(true);
     });
 
-    // The actual WebSocket message handling would be tested 
-    // through the useConnectionStatus mock integration
-    expect(result.current.dataSource).toBe('polling'); // Fallback initially
+    // useConnectionStatus is mocked as connected (isConnected: true), so with
+    // real-time enabled the hook selects the WebSocket data source.
+    await waitFor(() => {
+      expect(result.current.dataSource).toBe('websocket');
+    });
   });
 
   it('should handle different polling intervals', async () => {

--- a/dashboard/src/__tests__/hooks/useWebSocket.test.tsx
+++ b/dashboard/src/__tests__/hooks/useWebSocket.test.tsx
@@ -16,11 +16,9 @@ describe('useWebSocket', () => {
       useWebSocket('ws://localhost:3000/ws')
     );
 
-    // Initially disconnected
-    expect(result.current.isConnected).toBe(false);
-    expect(result.current.connectionStatus).toBe('disconnected');
-
-    // Wait for connection to establish
+    // The mount effect calls connect() immediately, so the initial
+    // 'disconnected' state is not observable here — assert the connection
+    // ultimately establishes (mock socket opens after a short delay).
     await waitFor(() => {
       expect(result.current.isConnected).toBe(true);
     }, { timeout: 5000 });
@@ -34,15 +32,14 @@ describe('useWebSocket', () => {
       useWebSocket('ws://localhost:3000/ws', { onError })
     );
 
-    // Wait for initial connection
+    // Wait until the hook has created its socket
     await waitFor(() => {
-      expect(result.current.connectionStatus).toBe('connecting');
+      expect(getMockWebSocket().last).toBeDefined();
     });
 
-    // Simulate error
+    // Simulate an error on the socket the hook actually created
     act(() => {
-      const mockWs = new (getMockWebSocket())('ws://localhost:3000/ws');
-      mockWs.simulateError();
+      getMockWebSocket().last.simulateError();
     });
 
     await waitFor(() => {
@@ -66,19 +63,22 @@ describe('useWebSocket', () => {
       expect(result.current.isConnected).toBe(true);
     });
 
-    // Simulate disconnection
+    const socketsBefore = getMockWebSocket().instances.length;
+
+    // Simulate disconnection on the hook's actual socket with a retryable code
     act(() => {
-      const mockWs = new (getMockWebSocket())('ws://localhost:3000/ws');
-      mockWs.simulateClose(1006, 'Connection lost');
+      getMockWebSocket().last.simulateClose(1006, 'Connection lost');
     });
 
     await waitFor(() => {
       expect(result.current.connectionStatus).toBe('disconnected');
     });
 
-    // Should attempt reconnection
+    // Should attempt reconnection — a new socket is created after the backoff.
+    // (Asserting on the transient 'connecting' state would be racy; the new
+    // socket instance is the durable evidence of a reconnect attempt.)
     await waitFor(() => {
-      expect(result.current.connectionStatus).toBe('connecting');
+      expect(getMockWebSocket().instances.length).toBeGreaterThan(socketsBefore);
     }, { timeout: 1000 });
   });
 
@@ -151,48 +151,55 @@ describe('useWebSocket', () => {
       expect(result.current.isConnected).toBe(true);
     });
 
-    // Simulate invalid JSON message
+    // Deliver invalid JSON through the hook's actual socket handler
     act(() => {
-      const mockWs = new (getMockWebSocket())('ws://localhost:3000/ws');
-      mockWs.onmessage?.({ data: 'invalid json{' } as MessageEvent);
+      getMockWebSocket().last.onmessage?.({ data: 'invalid json{' } as MessageEvent);
     });
 
-    // Should handle error and try to process as raw message
+    // Should handle the parse error and fall back to a raw message
     await waitFor(() => {
       expect(onMessage).toHaveBeenCalledWith({ type: 'raw', data: 'invalid json{' });
     });
   });
 
   it('should respect max reconnection attempts', async () => {
+    // Keep sockets in CONNECTING (never fire onopen) so a successful open can't
+    // reset reconnectAttempts — that lets the attempt counter actually climb to
+    // the max across repeated failures.
+    getMockWebSocket().autoConnect = false;
+
     const { result } = renderHook(() =>
       useWebSocket('ws://localhost:3000/ws', {
         reconnect: true,
         maxReconnectAttempts: 2,
-        reconnectInterval: 50
+        reconnectInterval: 30
       })
     );
 
-    // Wait for initial connection
+    // Mount creates the first socket
     await waitFor(() => {
-      expect(result.current.isConnected).toBe(true);
+      expect(getMockWebSocket().last).toBeDefined();
     });
 
-    // Simulate multiple connection failures
+    // Fail repeatedly. Each retryable close either schedules another reconnect
+    // (new socket) or, once the max is reached, flips to the error state.
     for (let i = 0; i < 3; i++) {
+      const socketsBefore = getMockWebSocket().instances.length;
+
       act(() => {
-        const mockWs = new (getMockWebSocket())('ws://localhost:3000/ws');
-        mockWs.simulateClose(1006, 'Connection lost');
+        getMockWebSocket().last.simulateClose(1006, 'Connection lost');
       });
 
       await waitFor(() => {
-        expect(result.current.connectionStatus).toBe('disconnected');
-      });
+        const reconnected = getMockWebSocket().instances.length > socketsBefore;
+        const errored = result.current.connectionStatus === 'error';
+        expect(reconnected || errored).toBe(true);
+      }, { timeout: 1000 });
 
-      // Wait for potential reconnection attempt
-      await new Promise(resolve => setTimeout(resolve, 100));
+      if (result.current.connectionStatus === 'error') break;
     }
 
-    // After max attempts, should be in error state
+    // After exceeding max attempts, should be in error state
     await waitFor(() => {
       expect(result.current.connectionStatus).toBe('error');
     }, { timeout: 1000 });

--- a/dashboard/src/components/ConnectionStatus.tsx
+++ b/dashboard/src/components/ConnectionStatus.tsx
@@ -91,6 +91,9 @@ export const ConnectionStatus = memo<ConnectionStatusProps>(({
     if (!lastUpdate) return 'Never';
     try {
       const date = new Date(lastUpdate);
+      // An unparseable date yields NaN getTime() (no throw), which would fall
+      // through to toLocaleTimeString() → "Invalid Date". Detect it explicitly.
+      if (isNaN(date.getTime())) return 'Invalid time';
       const now = new Date();
       const diffMs = now.getTime() - date.getTime();
       const diffSeconds = Math.floor(diffMs / 1000);

--- a/dashboard/src/hooks/useWebSocket.tsx
+++ b/dashboard/src/hooks/useWebSocket.tsx
@@ -41,6 +41,10 @@ export const useWebSocket = (url: string, options: WebSocketOptions = {}): WebSo
   const [latency, setLatency] = useState(0);
 
   const ws = useRef<WebSocket | null>(null);
+  // Set when the consumer calls disconnect() so the close handler does not
+  // schedule a reconnect for an intentional close (code 1000 is otherwise in
+  // the retryable set). Reset on each connect().
+  const intentionalClose = useRef(false);
   const reconnectAttempts = useRef(0);
   const reconnectTimeoutId = useRef<NodeJS.Timeout | null>(null);
   const heartbeatTimeoutId = useRef<NodeJS.Timeout | null>(null);
@@ -82,6 +86,7 @@ export const useWebSocket = (url: string, options: WebSocketOptions = {}): WebSo
 
   const connect = useCallback(() => {
     try {
+      intentionalClose.current = false;
       setConnectionStatus('connecting');
 
       // Enhanced connection validation
@@ -147,8 +152,10 @@ export const useWebSocket = (url: string, options: WebSocketOptions = {}): WebSo
         clearHeartbeatTimeout();
         onDisconnect?.();
 
-        // Enhanced reconnection logic with connection analysis
-        if (reconnect && reconnectAttempts.current < maxReconnectAttempts) {
+        // Enhanced reconnection logic with connection analysis. Skip entirely
+        // when the consumer asked to disconnect (an intentional close must stay
+        // closed and not schedule a reconnect).
+        if (!intentionalClose.current && reconnect && reconnectAttempts.current < maxReconnectAttempts) {
           // Analyze close code to determine if we should retry
           const shouldRetry = [1000, 1001, 1006, 1011, 1012, 1013, 1014].includes(event.code);
 
@@ -225,6 +232,7 @@ export const useWebSocket = (url: string, options: WebSocketOptions = {}): WebSo
   }, [connect]);
 
   const disconnect = useCallback(() => {
+    intentionalClose.current = true;
     clearReconnectTimeout();
     clearHeartbeatTimeout();
 

--- a/dashboard/src/setupTests.ts
+++ b/dashboard/src/setupTests.ts
@@ -7,6 +7,17 @@ class MockWebSocket {
   static CLOSING = 2;
   static CLOSED = 3;
 
+  // Registry so tests can drive the socket the hook actually created
+  // (the hook does `new WebSocket(url)` internally — tests must reach THAT
+  // instance, not a throwaway one). MockWebSocket.last is the newest socket.
+  static instances: MockWebSocket[] = [];
+  // When false, sockets stay CONNECTING (never fire onopen). Lets reconnection
+  // tests accumulate attempts without onopen resetting the counter.
+  static autoConnect = true;
+  static get last(): MockWebSocket {
+    return MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  }
+
   readyState = MockWebSocket.CONNECTING;
   url: string;
   onopen: ((event: Event) => void) | null = null;
@@ -16,13 +27,16 @@ class MockWebSocket {
 
   constructor(url: string) {
     this.url = url;
-    // Simulate connection after a short delay
-    setTimeout(() => {
-      this.readyState = MockWebSocket.OPEN;
-      if (this.onopen) {
-        this.onopen(new Event('open'));
-      }
-    }, 100);
+    MockWebSocket.instances.push(this);
+    if (MockWebSocket.autoConnect) {
+      // Simulate connection after a short delay
+      setTimeout(() => {
+        this.readyState = MockWebSocket.OPEN;
+        if (this.onopen) {
+          this.onopen(new Event('open'));
+        }
+      }, 100);
+    }
   }
 
   send(_data: string) {
@@ -93,14 +107,22 @@ global.fetch = jest.fn(() =>
   } as Response)
 );
 
-// Mock localStorage
+// Mock localStorage — jsdom provides a real localStorage that shadows a plain
+// `global.localStorage =` assignment, so define it as an own property on window.
+// getItem returns null by default (matches the real Storage API for missing
+// keys); the default is re-asserted in beforeEach so a per-test mockReturnValue
+// can't leak to later tests.
 const localStorageMock = {
-  getItem: jest.fn(),
+  getItem: jest.fn(() => null as string | null),
   setItem: jest.fn(),
   removeItem: jest.fn(),
   clear: jest.fn(),
 };
-global.localStorage = localStorageMock as any;
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  writable: true,
+  configurable: true,
+});
 
 // window.location (host/hostname/port/protocol) is provided by jest.config.js
 // testEnvironmentOptions.url ('http://localhost:3000'); jest 30 / jsdom no longer
@@ -117,8 +139,10 @@ console.warn = jest.fn((message: any) => {
 // Reset mocks between tests
 beforeEach(() => {
   jest.clearAllMocks();
-  localStorageMock.getItem.mockClear();
-  localStorageMock.setItem.mockClear();
-  localStorageMock.removeItem.mockClear();
-  localStorageMock.clear.mockClear();
+  // Re-assert the default after clearAllMocks (which clears calls but keeps a
+  // leaked per-test mockReturnValue).
+  localStorageMock.getItem.mockReturnValue(null);
+  // Reset WebSocket registry/behavior so tests don't see prior sockets.
+  MockWebSocket.instances = [];
+  MockWebSocket.autoConnect = true;
 });


### PR DESCRIPTION
## What

Follow-up to #51 (which repaired the jest **config** so the suite could run). With the suite running, **18 tests failed** — a mix of speculative test bugs (never executed before) and **two genuine production bugs** uncovered in the process. All 40 tests now pass.

### Test infrastructure (`setupTests.ts`)
- `MockWebSocket` registers instances (`MockWebSocket.last`) so tests drive the socket the **hook actually created**, not a throwaway instance; added an `autoConnect` toggle for reconnection tests.
- `localStorage` mock installed via `Object.defineProperty` (a plain `global.localStorage =` was shadowed by jsdom's real `Storage`); `getItem` defaults to `null` and is re-asserted each test to prevent per-test `mockReturnValue` leakage.

### Test fixes
- **ConnectionStatus:** `getAllByText` for label/latency rendered in both the status area and the always-mounted tooltip; assert lowercase `excellent` (the capital is CSS `capitalize`); freeze the clock with fake timers (component uses `new Date()`, not `Date.now()`) and assert a timezone-independent `HH:MM:SS` shape; correct `0 clients` / empty-`lastUpdate` expectations to the component's real behavior.
- **useWebSocket:** drive `MockWebSocket.last`; drop the unobservable initial `'disconnected'` assert (mount effect connects immediately); assert reconnection via new socket instances instead of the racy transient `'connecting'`; deterministic max-attempts test via `autoConnect=false`.
- **useAuditData:** `dataSource` is `'websocket'` (the `useConnectionStatus` mock is connected), not `'polling'`.

### Production bugs fixed
- **`ConnectionStatus`** — an invalid `lastUpdate` rendered `"Invalid Date"` instead of the intended `"Invalid time"` (`NaN` `getTime()` fell through to `toLocaleTimeString()`). Added an explicit `isNaN` check.
- **`useWebSocket`** — `disconnect()` closed with code `1000`, which is in the retryable set, so `onclose` scheduled a reconnect that `disconnect()` had already cleared. Net effect: the socket **reconnected ~1s after an intentional disconnect**, and the orphan timer leaked across tests. Added an `intentionalClose` guard so an intentional close stays closed.

## Verification
- `npx jest`: **40/40 pass**, stable over **5 consecutive runs** (timing-sensitive WS tests).
- `tsc --noEmit` ✓ · `npm run build` ✓ · lockfile unchanged.
- CI `lint-and-test` does not run dashboard tests, so no CI behavior change — but the suite is now green for when it does.

Closes operations #1787.

🤖 Generated with [Claude Code](https://claude.com/claude-code)